### PR TITLE
Refactor lookaround assertions

### DIFF
--- a/corpus/main.txt
+++ b/corpus/main.txt
@@ -197,6 +197,69 @@ Jack(?=Sprat)
           (pattern_character))))))
 
 ================================================================================
+negative lookahead
+================================================================================
+Jack(?!Sprat)
+--------------------------------------------------------------------------------
+
+(pattern
+  (term
+    (pattern_character)
+    (pattern_character)
+    (pattern_character)
+    (pattern_character)
+    (lookahead_assertion
+      (pattern
+        (term
+          (pattern_character)
+          (pattern_character)
+          (pattern_character)
+          (pattern_character)
+          (pattern_character))))))
+
+================================================================================
+lookbehind
+================================================================================
+(?<=Jack)Sprat
+--------------------------------------------------------------------------------
+
+(pattern
+  (term
+    (lookbehind_assertion
+      (pattern
+        (term
+          (pattern_character)
+          (pattern_character)
+          (pattern_character)
+          (pattern_character))))))
+    (pattern_character)
+    (pattern_character)
+    (pattern_character)
+    (pattern_character)
+    (pattern_character)
+
+================================================================================
+negative lookbehind
+================================================================================
+(?<!Jack)Sprat
+--------------------------------------------------------------------------------
+
+(pattern
+  (term
+    (lookbehind_assertion
+      (pattern
+        (term
+          (pattern_character)
+          (pattern_character)
+          (pattern_character)
+          (pattern_character))))))
+    (pattern_character)
+    (pattern_character)
+    (pattern_character)
+    (pattern_character)
+    (pattern_character)
+
+================================================================================
 character classes
 ================================================================================
 [A-Za-z][^Xx]

--- a/corpus/main.txt
+++ b/corpus/main.txt
@@ -187,7 +187,7 @@ Jack(?=Sprat)
     (pattern_character)
     (pattern_character)
     (pattern_character)
-    (lookahead_assertion
+    (lookaround_assertion
       (pattern
         (term
           (pattern_character)
@@ -208,7 +208,7 @@ Jack(?!Sprat)
     (pattern_character)
     (pattern_character)
     (pattern_character)
-    (lookahead_assertion
+    (lookaround_assertion
       (pattern
         (term
           (pattern_character)
@@ -225,18 +225,18 @@ lookbehind
 
 (pattern
   (term
-    (lookbehind_assertion
+    (lookaround_assertion
       (pattern
         (term
           (pattern_character)
           (pattern_character)
           (pattern_character)
-          (pattern_character))))))
+          (pattern_character))))
     (pattern_character)
     (pattern_character)
     (pattern_character)
     (pattern_character)
-    (pattern_character)
+    (pattern_character)))
 
 ================================================================================
 negative lookbehind
@@ -246,18 +246,18 @@ negative lookbehind
 
 (pattern
   (term
-    (lookbehind_assertion
+    (lookaround_assertion
       (pattern
         (term
           (pattern_character)
           (pattern_character)
           (pattern_character)
-          (pattern_character))))))
+          (pattern_character))))
     (pattern_character)
     (pattern_character)
     (pattern_character)
     (pattern_character)
-    (pattern_character)
+    (pattern_character)))
 
 ================================================================================
 character classes

--- a/grammar.js
+++ b/grammar.js
@@ -40,7 +40,7 @@ module.exports = grammar({
         $.end_assertion,
         $.boundary_assertion,
         $.non_boundary_assertion,
-        $.lookahead_assertion,
+        $.lookaround_assertion,
         $.pattern_character,
         $.character_class,
         $.any_character,
@@ -66,9 +66,19 @@ module.exports = grammar({
     end_assertion: $ => '$',
     boundary_assertion: $ => '\\b',
     non_boundary_assertion: $ => '\\B',
-    lookahead_assertion: $ => seq(
+    lookaround_assertion: $ => choice(
+      $._lookahead_assertion,
+      $._lookbehind_assertion
+    ),
+    _lookahead_assertion: $ => seq(
       '(?',
-      choice('=', '!', '<=', '<!'),
+      choice('=', '!'),
+      $.pattern,
+      ')'
+    ),
+    _lookbehind_assertion: $ => seq(
+      '(?<',
+      choice('=', '!'),
       $.pattern,
       ')'
     ),

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "nan": "^2.14.1"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.20.1"
+    "tree-sitter-cli": "^0.20.8"
   },
   "scripts": {
     "test": "tree-sitter test"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -30,9 +30,7 @@
   "?"
   "|"
   "="
-  "<="
   "!"
-  "<!"
 ] @operator
 
 (count_quantifier

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -81,7 +81,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "lookahead_assertion"
+                "name": "lookaround_assertion"
               },
               {
                 "type": "SYMBOL",
@@ -177,7 +177,20 @@
       "type": "STRING",
       "value": "\\B"
     },
-    "lookahead_assertion": {
+    "lookaround_assertion": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_lookahead_assertion"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_lookbehind_assertion"
+        }
+      ]
+    },
+    "_lookahead_assertion": {
       "type": "SEQ",
       "members": [
         {
@@ -194,14 +207,36 @@
             {
               "type": "STRING",
               "value": "!"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pattern"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "_lookbehind_assertion": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "(?<"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "="
             },
             {
               "type": "STRING",
-              "value": "<="
-            },
-            {
-              "type": "STRING",
-              "value": "<!"
+              "value": "!"
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -145,7 +145,7 @@
     }
   },
   {
-    "type": "lookahead_assertion",
+    "type": "lookaround_assertion",
     "named": true,
     "fields": {},
     "children": {
@@ -304,7 +304,7 @@
           "named": true
         },
         {
-          "type": "lookahead_assertion",
+          "type": "lookaround_assertion",
           "named": true
         },
         {
@@ -414,14 +414,6 @@
   },
   {
     "type": "-",
-    "named": false
-  },
-  {
-    "type": "<!",
-    "named": false
-  },
-  {
-    "type": "<=",
     "named": false
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,12 +5,12 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#define LANGUAGE_VERSION 13
-#define STATE_COUNT 75
-#define LARGE_STATE_COUNT 9
+#define LANGUAGE_VERSION 14
+#define STATE_COUNT 79
+#define LARGE_STATE_COUNT 10
 #define SYMBOL_COUNT 59
 #define ALIAS_COUNT 2
-#define TOKEN_COUNT 39
+#define TOKEN_COUNT 37
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -26,40 +26,40 @@ enum {
   anon_sym_LPAREN_QMARK = 7,
   anon_sym_EQ = 8,
   anon_sym_BANG = 9,
-  anon_sym_LT_EQ = 10,
-  anon_sym_LT_BANG = 11,
-  anon_sym_RPAREN = 12,
-  sym_pattern_character = 13,
-  anon_sym_LBRACK = 14,
-  anon_sym_RBRACK = 15,
-  anon_sym_DASH = 16,
-  anon_sym_BSLASH_DASH = 17,
-  sym_class_character = 18,
-  anon_sym_LPAREN = 19,
-  anon_sym_LPAREN_QMARK_LT = 20,
-  anon_sym_GT = 21,
-  anon_sym_LPAREN_QMARK_COLON = 22,
-  anon_sym_STAR = 23,
-  anon_sym_QMARK = 24,
-  anon_sym_PLUS = 25,
-  anon_sym_LBRACE = 26,
-  anon_sym_COMMA = 27,
-  anon_sym_RBRACE = 28,
-  anon_sym_BSLASHk = 29,
-  sym_decimal_escape = 30,
-  aux_sym_character_class_escape_token1 = 31,
-  aux_sym_character_class_escape_token2 = 32,
-  sym_unicode_property = 33,
-  sym_control_escape = 34,
-  sym_control_letter_escape = 35,
-  sym_identity_escape = 36,
-  sym_group_name = 37,
-  sym_decimal_digits = 38,
-  sym_pattern = 39,
-  sym_alternation = 40,
-  sym_term = 41,
-  sym_start_assertion = 42,
-  sym_lookahead_assertion = 43,
+  anon_sym_RPAREN = 10,
+  anon_sym_LPAREN_QMARK_LT = 11,
+  sym_pattern_character = 12,
+  anon_sym_LBRACK = 13,
+  anon_sym_RBRACK = 14,
+  anon_sym_DASH = 15,
+  anon_sym_BSLASH_DASH = 16,
+  sym_class_character = 17,
+  anon_sym_LPAREN = 18,
+  anon_sym_GT = 19,
+  anon_sym_LPAREN_QMARK_COLON = 20,
+  anon_sym_STAR = 21,
+  anon_sym_QMARK = 22,
+  anon_sym_PLUS = 23,
+  anon_sym_LBRACE = 24,
+  anon_sym_COMMA = 25,
+  anon_sym_RBRACE = 26,
+  anon_sym_BSLASHk = 27,
+  sym_decimal_escape = 28,
+  aux_sym_character_class_escape_token1 = 29,
+  aux_sym_character_class_escape_token2 = 30,
+  sym_unicode_property = 31,
+  sym_control_escape = 32,
+  sym_control_letter_escape = 33,
+  sym_identity_escape = 34,
+  sym_group_name = 35,
+  sym_decimal_digits = 36,
+  sym_pattern = 37,
+  sym_alternation = 38,
+  sym_term = 39,
+  sym_start_assertion = 40,
+  sym_lookaround_assertion = 41,
+  sym__lookahead_assertion = 42,
+  sym__lookbehind_assertion = 43,
   sym_character_class = 44,
   sym_class_range = 45,
   sym_anonymous_capturing_group = 46,
@@ -90,9 +90,8 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LPAREN_QMARK] = "(\?",
   [anon_sym_EQ] = "=",
   [anon_sym_BANG] = "!",
-  [anon_sym_LT_EQ] = "<=",
-  [anon_sym_LT_BANG] = "<!",
   [anon_sym_RPAREN] = ")",
+  [anon_sym_LPAREN_QMARK_LT] = "(\?<",
   [sym_pattern_character] = "pattern_character",
   [anon_sym_LBRACK] = "[",
   [anon_sym_RBRACK] = "]",
@@ -100,7 +99,6 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_BSLASH_DASH] = "identity_escape",
   [sym_class_character] = "class_character",
   [anon_sym_LPAREN] = "(",
-  [anon_sym_LPAREN_QMARK_LT] = "(\?<",
   [anon_sym_GT] = ">",
   [anon_sym_LPAREN_QMARK_COLON] = "(\?:",
   [anon_sym_STAR] = "*",
@@ -123,7 +121,9 @@ static const char * const ts_symbol_names[] = {
   [sym_alternation] = "alternation",
   [sym_term] = "term",
   [sym_start_assertion] = "start_assertion",
-  [sym_lookahead_assertion] = "lookahead_assertion",
+  [sym_lookaround_assertion] = "lookaround_assertion",
+  [sym__lookahead_assertion] = "_lookahead_assertion",
+  [sym__lookbehind_assertion] = "_lookbehind_assertion",
   [sym_character_class] = "character_class",
   [sym_class_range] = "class_range",
   [sym_anonymous_capturing_group] = "anonymous_capturing_group",
@@ -154,9 +154,8 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LPAREN_QMARK] = anon_sym_LPAREN_QMARK,
   [anon_sym_EQ] = anon_sym_EQ,
   [anon_sym_BANG] = anon_sym_BANG,
-  [anon_sym_LT_EQ] = anon_sym_LT_EQ,
-  [anon_sym_LT_BANG] = anon_sym_LT_BANG,
   [anon_sym_RPAREN] = anon_sym_RPAREN,
+  [anon_sym_LPAREN_QMARK_LT] = anon_sym_LPAREN_QMARK_LT,
   [sym_pattern_character] = sym_pattern_character,
   [anon_sym_LBRACK] = anon_sym_LBRACK,
   [anon_sym_RBRACK] = anon_sym_RBRACK,
@@ -164,7 +163,6 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_BSLASH_DASH] = sym_identity_escape,
   [sym_class_character] = sym_class_character,
   [anon_sym_LPAREN] = anon_sym_LPAREN,
-  [anon_sym_LPAREN_QMARK_LT] = anon_sym_LPAREN_QMARK_LT,
   [anon_sym_GT] = anon_sym_GT,
   [anon_sym_LPAREN_QMARK_COLON] = anon_sym_LPAREN_QMARK_COLON,
   [anon_sym_STAR] = anon_sym_STAR,
@@ -187,7 +185,9 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_alternation] = sym_alternation,
   [sym_term] = sym_term,
   [sym_start_assertion] = sym_start_assertion,
-  [sym_lookahead_assertion] = sym_lookahead_assertion,
+  [sym_lookaround_assertion] = sym_lookaround_assertion,
+  [sym__lookahead_assertion] = sym__lookahead_assertion,
+  [sym__lookbehind_assertion] = sym__lookbehind_assertion,
   [sym_character_class] = sym_character_class,
   [sym_class_range] = sym_class_range,
   [sym_anonymous_capturing_group] = sym_anonymous_capturing_group,
@@ -248,15 +248,11 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_LT_EQ] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_LT_BANG] = {
-    .visible = true,
-    .named = false,
-  },
   [anon_sym_RPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LPAREN_QMARK_LT] = {
     .visible = true,
     .named = false,
   },
@@ -285,10 +281,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [anon_sym_LPAREN] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_LPAREN_QMARK_LT] = {
     .visible = true,
     .named = false,
   },
@@ -380,8 +372,16 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_lookahead_assertion] = {
+  [sym_lookaround_assertion] = {
     .visible = true,
+    .named = true,
+  },
+  [sym__lookahead_assertion] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym__lookbehind_assertion] = {
+    .visible = false,
     .named = true,
   },
   [sym_character_class] = {
@@ -484,51 +484,133 @@ static const uint16_t ts_non_terminal_alias_map[] = {
   0,
 };
 
+static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
+  [0] = 0,
+  [1] = 1,
+  [2] = 2,
+  [3] = 3,
+  [4] = 4,
+  [5] = 5,
+  [6] = 6,
+  [7] = 7,
+  [8] = 8,
+  [9] = 9,
+  [10] = 10,
+  [11] = 11,
+  [12] = 12,
+  [13] = 13,
+  [14] = 14,
+  [15] = 15,
+  [16] = 16,
+  [17] = 17,
+  [18] = 18,
+  [19] = 19,
+  [20] = 20,
+  [21] = 21,
+  [22] = 22,
+  [23] = 23,
+  [24] = 24,
+  [25] = 25,
+  [26] = 26,
+  [27] = 27,
+  [28] = 28,
+  [29] = 29,
+  [30] = 30,
+  [31] = 31,
+  [32] = 32,
+  [33] = 33,
+  [34] = 34,
+  [35] = 35,
+  [36] = 36,
+  [37] = 37,
+  [38] = 38,
+  [39] = 39,
+  [40] = 40,
+  [41] = 41,
+  [42] = 42,
+  [43] = 43,
+  [44] = 44,
+  [45] = 11,
+  [46] = 46,
+  [47] = 47,
+  [48] = 48,
+  [49] = 18,
+  [50] = 50,
+  [51] = 51,
+  [52] = 52,
+  [53] = 53,
+  [54] = 54,
+  [55] = 55,
+  [56] = 56,
+  [57] = 57,
+  [58] = 58,
+  [59] = 59,
+  [60] = 59,
+  [61] = 61,
+  [62] = 62,
+  [63] = 63,
+  [64] = 64,
+  [65] = 65,
+  [66] = 66,
+  [67] = 67,
+  [68] = 68,
+  [69] = 69,
+  [70] = 70,
+  [71] = 71,
+  [72] = 72,
+  [73] = 73,
+  [74] = 74,
+  [75] = 75,
+  [76] = 74,
+  [77] = 77,
+  [78] = 62,
+};
+
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
   START_LEXER();
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(18);
+      if (eof) ADVANCE(17);
       if (lookahead == '\n') SKIP(0)
-      if (lookahead == '\r') SKIP(13)
-      if (lookahead == '!') ADVANCE(27);
-      if (lookahead == '$') ADVANCE(22);
-      if (lookahead == '(') ADVANCE(39);
-      if (lookahead == ')') ADVANCE(30);
-      if (lookahead == '*') ADVANCE(43);
-      if (lookahead == '+') ADVANCE(45);
-      if (lookahead == ',') ADVANCE(47);
-      if (lookahead == '-') ADVANCE(34);
-      if (lookahead == '.') ADVANCE(20);
-      if (lookahead == '=') ADVANCE(26);
-      if (lookahead == '>') ADVANCE(41);
-      if (lookahead == '?') ADVANCE(44);
-      if (lookahead == '[') ADVANCE(32);
-      if (lookahead == '\\') ADVANCE(10);
-      if (lookahead == ']') ADVANCE(33);
-      if (lookahead == '^') ADVANCE(21);
-      if (lookahead == '{') ADVANCE(46);
-      if (lookahead == '|') ADVANCE(19);
-      if (lookahead == '}') ADVANCE(48);
-      if (lookahead != 0) ADVANCE(31);
+      if (lookahead == '\r') SKIP(12)
+      if (lookahead == '!') ADVANCE(26);
+      if (lookahead == '$') ADVANCE(21);
+      if (lookahead == '(') ADVANCE(37);
+      if (lookahead == ')') ADVANCE(27);
+      if (lookahead == '*') ADVANCE(40);
+      if (lookahead == '+') ADVANCE(42);
+      if (lookahead == ',') ADVANCE(44);
+      if (lookahead == '-') ADVANCE(32);
+      if (lookahead == '.') ADVANCE(19);
+      if (lookahead == '=') ADVANCE(25);
+      if (lookahead == '>') ADVANCE(38);
+      if (lookahead == '?') ADVANCE(41);
+      if (lookahead == '[') ADVANCE(30);
+      if (lookahead == '\\') ADVANCE(9);
+      if (lookahead == ']') ADVANCE(31);
+      if (lookahead == '^') ADVANCE(20);
+      if (lookahead == '{') ADVANCE(43);
+      if (lookahead == '|') ADVANCE(18);
+      if (lookahead == '}') ADVANCE(45);
+      if (lookahead != 0) ADVANCE(29);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(37);
-      if (lookahead == '\r') ADVANCE(36);
-      if (lookahead == '-') ADVANCE(34);
-      if (lookahead == '\\') ADVANCE(11);
-      if (lookahead == ']') ADVANCE(33);
-      if (lookahead == '^') ADVANCE(21);
-      if (lookahead != 0) ADVANCE(36);
+      if (lookahead == '\n') ADVANCE(35);
+      if (lookahead == '\r') ADVANCE(34);
+      if (lookahead == '-') ADVANCE(32);
+      if (lookahead == '\\') ADVANCE(10);
+      if (lookahead == ']') ADVANCE(31);
+      if (lookahead == '^') ADVANCE(20);
+      if (lookahead != 0) ADVANCE(34);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(38);
-      if (lookahead == '\r') ADVANCE(36);
-      if (lookahead == '-') ADVANCE(34);
-      if (lookahead == '\\') ADVANCE(11);
-      if (lookahead == ']') ADVANCE(33);
-      if (lookahead != 0) ADVANCE(36);
+      if (lookahead == '\n') ADVANCE(36);
+      if (lookahead == '\r') ADVANCE(34);
+      if (lookahead == '-') ADVANCE(32);
+      if (lookahead == '\\') ADVANCE(10);
+      if (lookahead == ']') ADVANCE(31);
+      if (lookahead != 0) ADVANCE(34);
       END_STATE();
     case 3:
       if (lookahead == '\n') SKIP(4)
@@ -536,16 +618,14 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 4:
       if (lookahead == '\n') SKIP(4)
       if (lookahead == '\r') SKIP(3)
-      if (lookahead == '!') ADVANCE(27);
-      if (lookahead == ',') ADVANCE(47);
-      if (lookahead == '<') ADVANCE(9);
-      if (lookahead == '=') ADVANCE(26);
-      if (lookahead == '>') ADVANCE(41);
-      if (lookahead == '}') ADVANCE(48);
+      if (lookahead == '!') ADVANCE(26);
+      if (lookahead == ',') ADVANCE(44);
+      if (lookahead == '=') ADVANCE(25);
+      if (lookahead == '>') ADVANCE(38);
+      if (lookahead == '}') ADVANCE(45);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
       END_STATE();
     case 5:
       if (lookahead == '\n') SKIP(6)
@@ -555,7 +635,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\r') SKIP(5)
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
       END_STATE();
     case 7:
       if (lookahead == '\n') SKIP(8)
@@ -563,279 +644,269 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 8:
       if (lookahead == '\n') SKIP(8)
       if (lookahead == '\r') SKIP(7)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
       END_STATE();
     case 9:
-      if (lookahead == '!') ADVANCE(29);
-      if (lookahead == '=') ADVANCE(28);
-      END_STATE();
-    case 10:
-      if (lookahead == '-') ADVANCE(35);
-      if (lookahead == 'B') ADVANCE(24);
-      if (lookahead == 'b') ADVANCE(23);
-      if (lookahead == 'c') ADVANCE(57);
-      if (lookahead == 'k') ADVANCE(49);
+      if (lookahead == '-') ADVANCE(33);
+      if (lookahead == 'B') ADVANCE(23);
+      if (lookahead == 'b') ADVANCE(22);
+      if (lookahead == 'c') ADVANCE(54);
+      if (lookahead == 'k') ADVANCE(46);
       if (lookahead == 'P' ||
-          lookahead == 'p') ADVANCE(52);
+          lookahead == 'p') ADVANCE(49);
       if (lookahead == '0' ||
           lookahead == 'f' ||
           lookahead == 'n' ||
           lookahead == 'r' ||
           lookahead == 't' ||
-          lookahead == 'v') ADVANCE(54);
+          lookahead == 'v') ADVANCE(51);
       if (lookahead == 'D' ||
           lookahead == 'S' ||
           lookahead == 'W' ||
           lookahead == 'd' ||
           lookahead == 's' ||
-          lookahead == 'w') ADVANCE(51);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(50);
-      if (lookahead != 0) ADVANCE(56);
+          lookahead == 'w') ADVANCE(48);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(47);
+      if (lookahead != 0) ADVANCE(53);
       END_STATE();
-    case 11:
-      if (lookahead == '-') ADVANCE(35);
-      if (lookahead == 'c') ADVANCE(57);
+    case 10:
+      if (lookahead == '-') ADVANCE(33);
+      if (lookahead == 'c') ADVANCE(54);
       if (lookahead == 'P' ||
-          lookahead == 'p') ADVANCE(52);
+          lookahead == 'p') ADVANCE(49);
       if (lookahead == 'D' ||
           lookahead == 'S' ||
           lookahead == 'W' ||
           lookahead == 'd' ||
           lookahead == 's' ||
-          lookahead == 'w') ADVANCE(51);
+          lookahead == 'w') ADVANCE(48);
       if (lookahead == '0' ||
           lookahead == 'b' ||
           lookahead == 'f' ||
           lookahead == 'n' ||
           ('r' <= lookahead && lookahead <= 't') ||
-          lookahead == 'v') ADVANCE(54);
+          lookahead == 'v') ADVANCE(51);
       if (lookahead != 0 &&
           (lookahead < '1' || '9' < lookahead) &&
-          lookahead != 'k') ADVANCE(56);
+          lookahead != 'k') ADVANCE(53);
       END_STATE();
-    case 12:
-      if (lookahead == 'B') ADVANCE(24);
-      if (lookahead == 'b') ADVANCE(23);
-      if (lookahead == 'c') ADVANCE(57);
-      if (lookahead == 'k') ADVANCE(49);
+    case 11:
+      if (lookahead == 'B') ADVANCE(23);
+      if (lookahead == 'b') ADVANCE(22);
+      if (lookahead == 'c') ADVANCE(54);
+      if (lookahead == 'k') ADVANCE(46);
       if (lookahead == 'P' ||
-          lookahead == 'p') ADVANCE(52);
+          lookahead == 'p') ADVANCE(49);
       if (lookahead == '0' ||
           lookahead == 'f' ||
           lookahead == 'n' ||
           lookahead == 'r' ||
           lookahead == 't' ||
-          lookahead == 'v') ADVANCE(54);
+          lookahead == 'v') ADVANCE(51);
       if (lookahead == 'D' ||
           lookahead == 'S' ||
           lookahead == 'W' ||
           lookahead == 'd' ||
           lookahead == 's' ||
-          lookahead == 'w') ADVANCE(51);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(50);
-      if (lookahead != 0) ADVANCE(56);
+          lookahead == 'w') ADVANCE(48);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(47);
+      if (lookahead != 0) ADVANCE(53);
       END_STATE();
-    case 13:
-      if (eof) ADVANCE(18);
+    case 12:
+      if (eof) ADVANCE(17);
       if (lookahead == '\n') SKIP(0)
       END_STATE();
-    case 14:
-      if (eof) ADVANCE(18);
-      if (lookahead == '\n') SKIP(15)
+    case 13:
+      if (eof) ADVANCE(17);
+      if (lookahead == '\n') SKIP(14)
       END_STATE();
-    case 15:
-      if (eof) ADVANCE(18);
-      if (lookahead == '\n') SKIP(15)
-      if (lookahead == '\r') SKIP(14)
-      if (lookahead == '$') ADVANCE(22);
-      if (lookahead == '(') ADVANCE(39);
-      if (lookahead == ')') ADVANCE(30);
-      if (lookahead == '.') ADVANCE(20);
-      if (lookahead == '?') ADVANCE(44);
-      if (lookahead == '[') ADVANCE(32);
-      if (lookahead == '\\') ADVANCE(12);
-      if (lookahead == '^') ADVANCE(21);
-      if (lookahead == '|') ADVANCE(19);
+    case 14:
+      if (eof) ADVANCE(17);
+      if (lookahead == '\n') SKIP(14)
+      if (lookahead == '\r') SKIP(13)
+      if (lookahead == '$') ADVANCE(21);
+      if (lookahead == '(') ADVANCE(37);
+      if (lookahead == ')') ADVANCE(27);
+      if (lookahead == '.') ADVANCE(19);
+      if (lookahead == '?') ADVANCE(41);
+      if (lookahead == '[') ADVANCE(30);
+      if (lookahead == '\\') ADVANCE(11);
+      if (lookahead == '^') ADVANCE(20);
+      if (lookahead == '|') ADVANCE(18);
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '+' &&
-          lookahead != ']') ADVANCE(31);
+          lookahead != ']') ADVANCE(29);
+      END_STATE();
+    case 15:
+      if (eof) ADVANCE(17);
+      if (lookahead == '\n') SKIP(16)
       END_STATE();
     case 16:
-      if (eof) ADVANCE(18);
-      if (lookahead == '\n') SKIP(17)
+      if (eof) ADVANCE(17);
+      if (lookahead == '\n') SKIP(16)
+      if (lookahead == '\r') SKIP(15)
+      if (lookahead == '$') ADVANCE(21);
+      if (lookahead == '(') ADVANCE(37);
+      if (lookahead == ')') ADVANCE(27);
+      if (lookahead == '*') ADVANCE(40);
+      if (lookahead == '+') ADVANCE(42);
+      if (lookahead == '.') ADVANCE(19);
+      if (lookahead == '?') ADVANCE(41);
+      if (lookahead == '[') ADVANCE(30);
+      if (lookahead == '\\') ADVANCE(11);
+      if (lookahead == '^') ADVANCE(20);
+      if (lookahead == '{') ADVANCE(43);
+      if (lookahead == '|') ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != ']') ADVANCE(29);
       END_STATE();
     case 17:
-      if (eof) ADVANCE(18);
-      if (lookahead == '\n') SKIP(17)
-      if (lookahead == '\r') SKIP(16)
-      if (lookahead == '$') ADVANCE(22);
-      if (lookahead == '(') ADVANCE(39);
-      if (lookahead == ')') ADVANCE(30);
-      if (lookahead == '*') ADVANCE(43);
-      if (lookahead == '+') ADVANCE(45);
-      if (lookahead == '.') ADVANCE(20);
-      if (lookahead == '?') ADVANCE(44);
-      if (lookahead == '[') ADVANCE(32);
-      if (lookahead == '\\') ADVANCE(12);
-      if (lookahead == '^') ADVANCE(21);
-      if (lookahead == '{') ADVANCE(46);
-      if (lookahead == '|') ADVANCE(19);
-      if (lookahead != 0 &&
-          lookahead != ']') ADVANCE(31);
-      END_STATE();
-    case 18:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 19:
+    case 18:
       ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
-    case 20:
+    case 19:
       ACCEPT_TOKEN(sym_any_character);
       END_STATE();
-    case 21:
+    case 20:
       ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
-    case 22:
+    case 21:
       ACCEPT_TOKEN(sym_end_assertion);
       END_STATE();
-    case 23:
+    case 22:
       ACCEPT_TOKEN(sym_boundary_assertion);
       END_STATE();
-    case 24:
+    case 23:
       ACCEPT_TOKEN(sym_non_boundary_assertion);
       END_STATE();
-    case 25:
+    case 24:
       ACCEPT_TOKEN(anon_sym_LPAREN_QMARK);
-      if (lookahead == ':') ADVANCE(42);
-      if (lookahead == '<') ADVANCE(40);
+      if (lookahead == ':') ADVANCE(39);
+      if (lookahead == '<') ADVANCE(28);
       END_STATE();
-    case 26:
+    case 25:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
-    case 27:
+    case 26:
       ACCEPT_TOKEN(anon_sym_BANG);
       END_STATE();
-    case 28:
-      ACCEPT_TOKEN(anon_sym_LT_EQ);
-      END_STATE();
-    case 29:
-      ACCEPT_TOKEN(anon_sym_LT_BANG);
-      END_STATE();
-    case 30:
+    case 27:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 31:
+    case 28:
+      ACCEPT_TOKEN(anon_sym_LPAREN_QMARK_LT);
+      END_STATE();
+    case 29:
       ACCEPT_TOKEN(sym_pattern_character);
       END_STATE();
-    case 32:
+    case 30:
       ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
-    case 33:
+    case 31:
       ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
-    case 34:
+    case 32:
       ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
-    case 35:
+    case 33:
       ACCEPT_TOKEN(anon_sym_BSLASH_DASH);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(sym_class_character);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(sym_class_character);
+      if (lookahead == '\n') ADVANCE(35);
+      if (lookahead == '\r') ADVANCE(34);
+      if (lookahead == '^') ADVANCE(20);
+      if (lookahead != 0 &&
+          lookahead != '-' &&
+          lookahead != '\\' &&
+          lookahead != ']') ADVANCE(34);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(sym_class_character);
+      if (lookahead == '\n') ADVANCE(36);
+      if (lookahead == '\r') ADVANCE(34);
+      if (lookahead != 0 &&
+          lookahead != '-' &&
+          lookahead != '\\' &&
+          lookahead != ']') ADVANCE(34);
       END_STATE();
     case 37:
-      ACCEPT_TOKEN(sym_class_character);
-      if (lookahead == '\n') ADVANCE(37);
-      if (lookahead == '\r') ADVANCE(36);
-      if (lookahead == '^') ADVANCE(21);
-      if (lookahead != 0 &&
-          lookahead != '-' &&
-          lookahead != '\\' &&
-          lookahead != ']') ADVANCE(36);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == '?') ADVANCE(24);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(sym_class_character);
-      if (lookahead == '\n') ADVANCE(38);
-      if (lookahead == '\r') ADVANCE(36);
-      if (lookahead != 0 &&
-          lookahead != '-' &&
-          lookahead != '\\' &&
-          lookahead != ']') ADVANCE(36);
-      END_STATE();
-    case 39:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == '?') ADVANCE(25);
-      END_STATE();
-    case 40:
-      ACCEPT_TOKEN(anon_sym_LPAREN_QMARK_LT);
-      END_STATE();
-    case 41:
       ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
-    case 42:
+    case 39:
       ACCEPT_TOKEN(anon_sym_LPAREN_QMARK_COLON);
       END_STATE();
-    case 43:
+    case 40:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 44:
+    case 41:
       ACCEPT_TOKEN(anon_sym_QMARK);
       END_STATE();
-    case 45:
+    case 42:
       ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
-    case 46:
+    case 43:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 47:
+    case 44:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 48:
+    case 45:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 49:
+    case 46:
       ACCEPT_TOKEN(anon_sym_BSLASHk);
       END_STATE();
-    case 50:
+    case 47:
       ACCEPT_TOKEN(sym_decimal_escape);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(50);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(47);
       END_STATE();
-    case 51:
+    case 48:
       ACCEPT_TOKEN(aux_sym_character_class_escape_token1);
       END_STATE();
-    case 52:
+    case 49:
       ACCEPT_TOKEN(aux_sym_character_class_escape_token2);
       END_STATE();
-    case 53:
+    case 50:
       ACCEPT_TOKEN(sym_unicode_property);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(53);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
       END_STATE();
-    case 54:
+    case 51:
       ACCEPT_TOKEN(sym_control_escape);
       END_STATE();
-    case 55:
+    case 52:
       ACCEPT_TOKEN(sym_control_letter_escape);
       END_STATE();
-    case 56:
+    case 53:
       ACCEPT_TOKEN(sym_identity_escape);
       END_STATE();
-    case 57:
+    case 54:
       ACCEPT_TOKEN(sym_identity_escape);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(52);
       END_STATE();
-    case 58:
+    case 55:
       ACCEPT_TOKEN(sym_group_name);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
       END_STATE();
-    case 59:
+    case 56:
       ACCEPT_TOKEN(sym_decimal_digits);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
       END_STATE();
     default:
       return false;
@@ -844,41 +915,41 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 15},
-  [2] = {.lex_state = 15},
-  [3] = {.lex_state = 15},
-  [4] = {.lex_state = 15},
-  [5] = {.lex_state = 15},
-  [6] = {.lex_state = 15},
-  [7] = {.lex_state = 15},
-  [8] = {.lex_state = 15},
-  [9] = {.lex_state = 17},
-  [10] = {.lex_state = 17},
-  [11] = {.lex_state = 17},
-  [12] = {.lex_state = 17},
-  [13] = {.lex_state = 17},
-  [14] = {.lex_state = 17},
-  [15] = {.lex_state = 17},
-  [16] = {.lex_state = 17},
-  [17] = {.lex_state = 17},
-  [18] = {.lex_state = 17},
-  [19] = {.lex_state = 17},
-  [20] = {.lex_state = 17},
-  [21] = {.lex_state = 15},
-  [22] = {.lex_state = 15},
-  [23] = {.lex_state = 15},
-  [24] = {.lex_state = 15},
-  [25] = {.lex_state = 15},
-  [26] = {.lex_state = 15},
-  [27] = {.lex_state = 15},
-  [28] = {.lex_state = 15},
-  [29] = {.lex_state = 15},
-  [30] = {.lex_state = 15},
-  [31] = {.lex_state = 15},
-  [32] = {.lex_state = 1},
-  [33] = {.lex_state = 2},
-  [34] = {.lex_state = 2},
-  [35] = {.lex_state = 2},
+  [1] = {.lex_state = 14},
+  [2] = {.lex_state = 14},
+  [3] = {.lex_state = 14},
+  [4] = {.lex_state = 14},
+  [5] = {.lex_state = 14},
+  [6] = {.lex_state = 14},
+  [7] = {.lex_state = 14},
+  [8] = {.lex_state = 14},
+  [9] = {.lex_state = 14},
+  [10] = {.lex_state = 16},
+  [11] = {.lex_state = 16},
+  [12] = {.lex_state = 16},
+  [13] = {.lex_state = 16},
+  [14] = {.lex_state = 16},
+  [15] = {.lex_state = 16},
+  [16] = {.lex_state = 16},
+  [17] = {.lex_state = 16},
+  [18] = {.lex_state = 16},
+  [19] = {.lex_state = 16},
+  [20] = {.lex_state = 16},
+  [21] = {.lex_state = 16},
+  [22] = {.lex_state = 16},
+  [23] = {.lex_state = 16},
+  [24] = {.lex_state = 14},
+  [25] = {.lex_state = 14},
+  [26] = {.lex_state = 14},
+  [27] = {.lex_state = 14},
+  [28] = {.lex_state = 14},
+  [29] = {.lex_state = 14},
+  [30] = {.lex_state = 14},
+  [31] = {.lex_state = 14},
+  [32] = {.lex_state = 14},
+  [33] = {.lex_state = 14},
+  [34] = {.lex_state = 14},
+  [35] = {.lex_state = 1},
   [36] = {.lex_state = 2},
   [37] = {.lex_state = 2},
   [38] = {.lex_state = 2},
@@ -890,34 +961,38 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [44] = {.lex_state = 2},
   [45] = {.lex_state = 2},
   [46] = {.lex_state = 2},
-  [47] = {.lex_state = 0},
-  [48] = {.lex_state = 0},
-  [49] = {.lex_state = 0},
+  [47] = {.lex_state = 2},
+  [48] = {.lex_state = 2},
+  [49] = {.lex_state = 2},
   [50] = {.lex_state = 0},
-  [51] = {.lex_state = 4},
+  [51] = {.lex_state = 0},
   [52] = {.lex_state = 0},
-  [53] = {.lex_state = 4},
+  [53] = {.lex_state = 0},
   [54] = {.lex_state = 4},
-  [55] = {.lex_state = 4},
-  [56] = {.lex_state = 0},
+  [55] = {.lex_state = 0},
+  [56] = {.lex_state = 4},
   [57] = {.lex_state = 4},
-  [58] = {.lex_state = 4},
+  [58] = {.lex_state = 0},
   [59] = {.lex_state = 6},
-  [60] = {.lex_state = 0},
-  [61] = {.lex_state = 0},
-  [62] = {.lex_state = 4},
-  [63] = {.lex_state = 6},
-  [64] = {.lex_state = 4},
-  [65] = {.lex_state = 8},
-  [66] = {.lex_state = 8},
-  [67] = {.lex_state = 4},
-  [68] = {.lex_state = 0},
+  [60] = {.lex_state = 6},
+  [61] = {.lex_state = 4},
+  [62] = {.lex_state = 0},
+  [63] = {.lex_state = 0},
+  [64] = {.lex_state = 0},
+  [65] = {.lex_state = 4},
+  [66] = {.lex_state = 6},
+  [67] = {.lex_state = 0},
+  [68] = {.lex_state = 4},
   [69] = {.lex_state = 0},
-  [70] = {.lex_state = 4},
-  [71] = {.lex_state = 0},
-  [72] = {.lex_state = 4},
-  [73] = {.lex_state = 0},
-  [74] = {.lex_state = 0},
+  [70] = {.lex_state = 0},
+  [71] = {.lex_state = 4},
+  [72] = {.lex_state = 8},
+  [73] = {.lex_state = 4},
+  [74] = {.lex_state = 4},
+  [75] = {.lex_state = 8},
+  [76] = {.lex_state = 4},
+  [77] = {.lex_state = 0},
+  [78] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -933,13 +1008,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_EQ] = ACTIONS(1),
     [anon_sym_BANG] = ACTIONS(1),
     [anon_sym_RPAREN] = ACTIONS(1),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(1),
     [sym_pattern_character] = ACTIONS(1),
     [anon_sym_LBRACK] = ACTIONS(1),
     [anon_sym_RBRACK] = ACTIONS(1),
     [anon_sym_DASH] = ACTIONS(1),
     [anon_sym_BSLASH_DASH] = ACTIONS(1),
     [anon_sym_LPAREN] = ACTIONS(1),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(1),
     [anon_sym_GT] = ACTIONS(1),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(1),
     [anon_sym_STAR] = ACTIONS(1),
@@ -957,19 +1032,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identity_escape] = ACTIONS(1),
   },
   [1] = {
-    [sym_pattern] = STATE(73),
-    [sym_alternation] = STATE(56),
-    [sym_term] = STATE(49),
-    [sym_start_assertion] = STATE(9),
-    [sym_lookahead_assertion] = STATE(9),
-    [sym_character_class] = STATE(9),
-    [sym_anonymous_capturing_group] = STATE(9),
-    [sym_named_capturing_group] = STATE(9),
-    [sym_non_capturing_group] = STATE(9),
-    [sym_backreference_escape] = STATE(9),
-    [sym_character_class_escape] = STATE(9),
-    [aux_sym_alternation_repeat1] = STATE(47),
-    [aux_sym_term_repeat1] = STATE(8),
+    [sym_pattern] = STATE(70),
+    [sym_alternation] = STATE(58),
+    [sym_term] = STATE(53),
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_alternation_repeat1] = STATE(52),
+    [aux_sym_term_repeat1] = STATE(9),
     [anon_sym_PIPE] = ACTIONS(3),
     [sym_any_character] = ACTIONS(5),
     [anon_sym_CARET] = ACTIONS(7),
@@ -977,10 +1054,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_boundary_assertion] = ACTIONS(5),
     [sym_non_boundary_assertion] = ACTIONS(5),
     [anon_sym_LPAREN_QMARK] = ACTIONS(9),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(11),
     [sym_pattern_character] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(13),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(15),
+    [anon_sym_LBRACK] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(17),
     [anon_sym_BSLASHk] = ACTIONS(19),
     [sym_decimal_escape] = ACTIONS(5),
@@ -991,19 +1068,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identity_escape] = ACTIONS(25),
   },
   [2] = {
-    [sym_pattern] = STATE(60),
-    [sym_alternation] = STATE(56),
-    [sym_term] = STATE(49),
-    [sym_start_assertion] = STATE(9),
-    [sym_lookahead_assertion] = STATE(9),
-    [sym_character_class] = STATE(9),
-    [sym_anonymous_capturing_group] = STATE(9),
-    [sym_named_capturing_group] = STATE(9),
-    [sym_non_capturing_group] = STATE(9),
-    [sym_backreference_escape] = STATE(9),
-    [sym_character_class_escape] = STATE(9),
-    [aux_sym_alternation_repeat1] = STATE(47),
-    [aux_sym_term_repeat1] = STATE(8),
+    [sym_pattern] = STATE(77),
+    [sym_alternation] = STATE(58),
+    [sym_term] = STATE(53),
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_alternation_repeat1] = STATE(52),
+    [aux_sym_term_repeat1] = STATE(9),
     [anon_sym_PIPE] = ACTIONS(3),
     [sym_any_character] = ACTIONS(5),
     [anon_sym_CARET] = ACTIONS(7),
@@ -1011,10 +1090,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_boundary_assertion] = ACTIONS(5),
     [sym_non_boundary_assertion] = ACTIONS(5),
     [anon_sym_LPAREN_QMARK] = ACTIONS(9),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(11),
     [sym_pattern_character] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(13),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(15),
+    [anon_sym_LBRACK] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(17),
     [anon_sym_BSLASHk] = ACTIONS(19),
     [sym_decimal_escape] = ACTIONS(5),
@@ -1025,19 +1104,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identity_escape] = ACTIONS(25),
   },
   [3] = {
-    [sym_pattern] = STATE(61),
-    [sym_alternation] = STATE(56),
-    [sym_term] = STATE(49),
-    [sym_start_assertion] = STATE(9),
-    [sym_lookahead_assertion] = STATE(9),
-    [sym_character_class] = STATE(9),
-    [sym_anonymous_capturing_group] = STATE(9),
-    [sym_named_capturing_group] = STATE(9),
-    [sym_non_capturing_group] = STATE(9),
-    [sym_backreference_escape] = STATE(9),
-    [sym_character_class_escape] = STATE(9),
-    [aux_sym_alternation_repeat1] = STATE(47),
-    [aux_sym_term_repeat1] = STATE(8),
+    [sym_pattern] = STATE(63),
+    [sym_alternation] = STATE(58),
+    [sym_term] = STATE(53),
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_alternation_repeat1] = STATE(52),
+    [aux_sym_term_repeat1] = STATE(9),
     [anon_sym_PIPE] = ACTIONS(3),
     [sym_any_character] = ACTIONS(5),
     [anon_sym_CARET] = ACTIONS(7),
@@ -1045,10 +1126,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_boundary_assertion] = ACTIONS(5),
     [sym_non_boundary_assertion] = ACTIONS(5),
     [anon_sym_LPAREN_QMARK] = ACTIONS(9),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(11),
     [sym_pattern_character] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(13),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(15),
+    [anon_sym_LBRACK] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(17),
     [anon_sym_BSLASHk] = ACTIONS(19),
     [sym_decimal_escape] = ACTIONS(5),
@@ -1059,19 +1140,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identity_escape] = ACTIONS(25),
   },
   [4] = {
-    [sym_pattern] = STATE(71),
-    [sym_alternation] = STATE(56),
-    [sym_term] = STATE(49),
-    [sym_start_assertion] = STATE(9),
-    [sym_lookahead_assertion] = STATE(9),
-    [sym_character_class] = STATE(9),
-    [sym_anonymous_capturing_group] = STATE(9),
-    [sym_named_capturing_group] = STATE(9),
-    [sym_non_capturing_group] = STATE(9),
-    [sym_backreference_escape] = STATE(9),
-    [sym_character_class_escape] = STATE(9),
-    [aux_sym_alternation_repeat1] = STATE(47),
-    [aux_sym_term_repeat1] = STATE(8),
+    [sym_pattern] = STATE(69),
+    [sym_alternation] = STATE(58),
+    [sym_term] = STATE(53),
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_alternation_repeat1] = STATE(52),
+    [aux_sym_term_repeat1] = STATE(9),
     [anon_sym_PIPE] = ACTIONS(3),
     [sym_any_character] = ACTIONS(5),
     [anon_sym_CARET] = ACTIONS(7),
@@ -1079,10 +1162,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_boundary_assertion] = ACTIONS(5),
     [sym_non_boundary_assertion] = ACTIONS(5),
     [anon_sym_LPAREN_QMARK] = ACTIONS(9),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(11),
     [sym_pattern_character] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(13),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(15),
+    [anon_sym_LBRACK] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(17),
     [anon_sym_BSLASHk] = ACTIONS(19),
     [sym_decimal_escape] = ACTIONS(5),
@@ -1093,19 +1176,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identity_escape] = ACTIONS(25),
   },
   [5] = {
-    [sym_pattern] = STATE(69),
-    [sym_alternation] = STATE(56),
-    [sym_term] = STATE(49),
-    [sym_start_assertion] = STATE(9),
-    [sym_lookahead_assertion] = STATE(9),
-    [sym_character_class] = STATE(9),
-    [sym_anonymous_capturing_group] = STATE(9),
-    [sym_named_capturing_group] = STATE(9),
-    [sym_non_capturing_group] = STATE(9),
-    [sym_backreference_escape] = STATE(9),
-    [sym_character_class_escape] = STATE(9),
-    [aux_sym_alternation_repeat1] = STATE(47),
-    [aux_sym_term_repeat1] = STATE(8),
+    [sym_pattern] = STATE(67),
+    [sym_alternation] = STATE(58),
+    [sym_term] = STATE(53),
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_alternation_repeat1] = STATE(52),
+    [aux_sym_term_repeat1] = STATE(9),
     [anon_sym_PIPE] = ACTIONS(3),
     [sym_any_character] = ACTIONS(5),
     [anon_sym_CARET] = ACTIONS(7),
@@ -1113,10 +1198,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_boundary_assertion] = ACTIONS(5),
     [sym_non_boundary_assertion] = ACTIONS(5),
     [anon_sym_LPAREN_QMARK] = ACTIONS(9),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(11),
     [sym_pattern_character] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(13),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(15),
+    [anon_sym_LBRACK] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(17),
     [anon_sym_BSLASHk] = ACTIONS(19),
     [sym_decimal_escape] = ACTIONS(5),
@@ -1127,29 +1212,32 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identity_escape] = ACTIONS(25),
   },
   [6] = {
-    [sym_term] = STATE(52),
-    [sym_start_assertion] = STATE(9),
-    [sym_lookahead_assertion] = STATE(9),
-    [sym_character_class] = STATE(9),
-    [sym_anonymous_capturing_group] = STATE(9),
-    [sym_named_capturing_group] = STATE(9),
-    [sym_non_capturing_group] = STATE(9),
-    [sym_backreference_escape] = STATE(9),
-    [sym_character_class_escape] = STATE(9),
-    [aux_sym_term_repeat1] = STATE(8),
-    [ts_builtin_sym_end] = ACTIONS(27),
-    [anon_sym_PIPE] = ACTIONS(27),
+    [sym_pattern] = STATE(64),
+    [sym_alternation] = STATE(58),
+    [sym_term] = STATE(53),
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_alternation_repeat1] = STATE(52),
+    [aux_sym_term_repeat1] = STATE(9),
+    [anon_sym_PIPE] = ACTIONS(3),
     [sym_any_character] = ACTIONS(5),
     [anon_sym_CARET] = ACTIONS(7),
     [sym_end_assertion] = ACTIONS(5),
     [sym_boundary_assertion] = ACTIONS(5),
     [sym_non_boundary_assertion] = ACTIONS(5),
     [anon_sym_LPAREN_QMARK] = ACTIONS(9),
-    [anon_sym_RPAREN] = ACTIONS(27),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(11),
     [sym_pattern_character] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(13),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(15),
+    [anon_sym_LBRACK] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(17),
     [anon_sym_BSLASHk] = ACTIONS(19),
     [sym_decimal_escape] = ACTIONS(5),
@@ -1160,15 +1248,52 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identity_escape] = ACTIONS(25),
   },
   [7] = {
-    [sym_start_assertion] = STATE(9),
-    [sym_lookahead_assertion] = STATE(9),
-    [sym_character_class] = STATE(9),
-    [sym_anonymous_capturing_group] = STATE(9),
-    [sym_named_capturing_group] = STATE(9),
-    [sym_non_capturing_group] = STATE(9),
-    [sym_backreference_escape] = STATE(9),
-    [sym_character_class_escape] = STATE(9),
-    [aux_sym_term_repeat1] = STATE(7),
+    [sym_term] = STATE(55),
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_term_repeat1] = STATE(9),
+    [ts_builtin_sym_end] = ACTIONS(27),
+    [anon_sym_PIPE] = ACTIONS(27),
+    [sym_any_character] = ACTIONS(5),
+    [anon_sym_CARET] = ACTIONS(7),
+    [sym_end_assertion] = ACTIONS(5),
+    [sym_boundary_assertion] = ACTIONS(5),
+    [sym_non_boundary_assertion] = ACTIONS(5),
+    [anon_sym_LPAREN_QMARK] = ACTIONS(9),
+    [anon_sym_RPAREN] = ACTIONS(27),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(11),
+    [sym_pattern_character] = ACTIONS(5),
+    [anon_sym_LBRACK] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
+    [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(17),
+    [anon_sym_BSLASHk] = ACTIONS(19),
+    [sym_decimal_escape] = ACTIONS(5),
+    [aux_sym_character_class_escape_token1] = ACTIONS(21),
+    [aux_sym_character_class_escape_token2] = ACTIONS(23),
+    [sym_control_escape] = ACTIONS(25),
+    [sym_control_letter_escape] = ACTIONS(5),
+    [sym_identity_escape] = ACTIONS(25),
+  },
+  [8] = {
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_term_repeat1] = STATE(8),
     [ts_builtin_sym_end] = ACTIONS(29),
     [anon_sym_PIPE] = ACTIONS(29),
     [sym_any_character] = ACTIONS(31),
@@ -1178,10 +1303,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_non_boundary_assertion] = ACTIONS(31),
     [anon_sym_LPAREN_QMARK] = ACTIONS(37),
     [anon_sym_RPAREN] = ACTIONS(29),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(40),
     [sym_pattern_character] = ACTIONS(31),
-    [anon_sym_LBRACK] = ACTIONS(40),
-    [anon_sym_LPAREN] = ACTIONS(43),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(46),
+    [anon_sym_LBRACK] = ACTIONS(43),
+    [anon_sym_LPAREN] = ACTIONS(46),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(49),
     [anon_sym_BSLASHk] = ACTIONS(52),
     [sym_decimal_escape] = ACTIONS(31),
@@ -1191,16 +1316,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_control_letter_escape] = ACTIONS(31),
     [sym_identity_escape] = ACTIONS(61),
   },
-  [8] = {
-    [sym_start_assertion] = STATE(9),
-    [sym_lookahead_assertion] = STATE(9),
-    [sym_character_class] = STATE(9),
-    [sym_anonymous_capturing_group] = STATE(9),
-    [sym_named_capturing_group] = STATE(9),
-    [sym_non_capturing_group] = STATE(9),
-    [sym_backreference_escape] = STATE(9),
-    [sym_character_class_escape] = STATE(9),
-    [aux_sym_term_repeat1] = STATE(7),
+  [9] = {
+    [sym_start_assertion] = STATE(10),
+    [sym_lookaround_assertion] = STATE(10),
+    [sym__lookahead_assertion] = STATE(16),
+    [sym__lookbehind_assertion] = STATE(16),
+    [sym_character_class] = STATE(10),
+    [sym_anonymous_capturing_group] = STATE(10),
+    [sym_named_capturing_group] = STATE(10),
+    [sym_non_capturing_group] = STATE(10),
+    [sym_backreference_escape] = STATE(10),
+    [sym_character_class_escape] = STATE(10),
+    [aux_sym_term_repeat1] = STATE(8),
     [ts_builtin_sym_end] = ACTIONS(64),
     [anon_sym_PIPE] = ACTIONS(64),
     [sym_any_character] = ACTIONS(5),
@@ -1210,10 +1337,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_non_boundary_assertion] = ACTIONS(5),
     [anon_sym_LPAREN_QMARK] = ACTIONS(9),
     [anon_sym_RPAREN] = ACTIONS(64),
+    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(11),
     [sym_pattern_character] = ACTIONS(5),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [anon_sym_LPAREN] = ACTIONS(13),
-    [anon_sym_LPAREN_QMARK_LT] = ACTIONS(15),
+    [anon_sym_LBRACK] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
     [anon_sym_LPAREN_QMARK_COLON] = ACTIONS(17),
     [anon_sym_BSLASHk] = ACTIONS(19),
     [sym_decimal_escape] = ACTIONS(5),
@@ -1235,7 +1362,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PLUS,
     ACTIONS(76), 1,
       anon_sym_LBRACE,
-    STATE(27), 4,
+    STATE(31), 4,
       sym_zero_or_more,
       sym_one_or_more,
       sym_optional,
@@ -1255,8 +1382,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_BSLASHk,
       sym_decimal_escape,
@@ -1279,8 +1406,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1307,8 +1434,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1335,8 +1462,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1363,8 +1490,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1391,8 +1518,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1419,8 +1546,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1447,8 +1574,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1475,8 +1602,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1503,8 +1630,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1531,8 +1658,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1559,8 +1686,8 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_STAR,
       anon_sym_QMARK,
@@ -1571,15 +1698,42 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_character_class_escape_token1,
       aux_sym_character_class_escape_token2,
       sym_control_letter_escape,
-  [374] = 3,
-    ACTIONS(126), 1,
+  [374] = 2,
+    ACTIONS(124), 5,
+      anon_sym_LPAREN_QMARK,
+      sym_pattern_character,
+      anon_sym_LPAREN,
+      sym_control_escape,
+      sym_identity_escape,
+    ACTIONS(122), 20,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_any_character,
+      anon_sym_CARET,
+      sym_end_assertion,
+      sym_boundary_assertion,
+      sym_non_boundary_assertion,
+      anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
+      anon_sym_LPAREN_QMARK_COLON,
+      anon_sym_STAR,
       anon_sym_QMARK,
-    ACTIONS(124), 4,
+      anon_sym_PLUS,
+      anon_sym_LBRACE,
+      anon_sym_BSLASHk,
+      sym_decimal_escape,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_letter_escape,
+  [404] = 2,
+    ACTIONS(128), 5,
       anon_sym_LPAREN_QMARK,
+      sym_pattern_character,
       anon_sym_LPAREN,
       sym_control_escape,
       sym_identity_escape,
-    ACTIONS(122), 17,
+    ACTIONS(126), 20,
       ts_builtin_sym_end,
       anon_sym_PIPE,
       sym_any_character,
@@ -1588,50 +1742,27 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
-      sym_pattern_character,
-      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_LT,
+      anon_sym_LBRACK,
       anon_sym_LPAREN_QMARK_COLON,
-      anon_sym_BSLASHk,
-      sym_decimal_escape,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_letter_escape,
-  [403] = 3,
-    ACTIONS(132), 1,
+      anon_sym_STAR,
       anon_sym_QMARK,
-    ACTIONS(130), 4,
-      anon_sym_LPAREN_QMARK,
-      anon_sym_LPAREN,
-      sym_control_escape,
-      sym_identity_escape,
-    ACTIONS(128), 17,
-      ts_builtin_sym_end,
-      anon_sym_PIPE,
-      sym_any_character,
-      anon_sym_CARET,
-      sym_end_assertion,
-      sym_boundary_assertion,
-      sym_non_boundary_assertion,
-      anon_sym_RPAREN,
-      sym_pattern_character,
-      anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
-      anon_sym_LPAREN_QMARK_COLON,
+      anon_sym_PLUS,
+      anon_sym_LBRACE,
       anon_sym_BSLASHk,
       sym_decimal_escape,
       aux_sym_character_class_escape_token1,
       aux_sym_character_class_escape_token2,
       sym_control_letter_escape,
-  [432] = 3,
-    ACTIONS(138), 1,
+  [434] = 3,
+    ACTIONS(134), 1,
       anon_sym_QMARK,
-    ACTIONS(136), 4,
+    ACTIONS(132), 4,
       anon_sym_LPAREN_QMARK,
       anon_sym_LPAREN,
       sym_control_escape,
       sym_identity_escape,
-    ACTIONS(134), 17,
+    ACTIONS(130), 17,
       ts_builtin_sym_end,
       anon_sym_PIPE,
       sym_any_character,
@@ -1640,24 +1771,24 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
       sym_pattern_character,
       anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_BSLASHk,
       sym_decimal_escape,
       aux_sym_character_class_escape_token1,
       aux_sym_character_class_escape_token2,
       sym_control_letter_escape,
-  [461] = 3,
-    ACTIONS(144), 1,
+  [463] = 3,
+    ACTIONS(140), 1,
       anon_sym_QMARK,
-    ACTIONS(142), 4,
+    ACTIONS(138), 4,
       anon_sym_LPAREN_QMARK,
       anon_sym_LPAREN,
       sym_control_escape,
       sym_identity_escape,
-    ACTIONS(140), 17,
+    ACTIONS(136), 17,
       ts_builtin_sym_end,
       anon_sym_PIPE,
       sym_any_character,
@@ -1666,24 +1797,24 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
       sym_pattern_character,
       anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_BSLASHk,
       sym_decimal_escape,
       aux_sym_character_class_escape_token1,
       aux_sym_character_class_escape_token2,
       sym_control_letter_escape,
-  [490] = 3,
-    ACTIONS(150), 1,
+  [492] = 3,
+    ACTIONS(146), 1,
       anon_sym_QMARK,
-    ACTIONS(148), 4,
+    ACTIONS(144), 4,
       anon_sym_LPAREN_QMARK,
       anon_sym_LPAREN,
       sym_control_escape,
       sym_identity_escape,
-    ACTIONS(146), 17,
+    ACTIONS(142), 17,
       ts_builtin_sym_end,
       anon_sym_PIPE,
       sym_any_character,
@@ -1692,22 +1823,24 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
       sym_pattern_character,
       anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_BSLASHk,
       sym_decimal_escape,
       aux_sym_character_class_escape_token1,
       aux_sym_character_class_escape_token2,
       sym_control_letter_escape,
-  [519] = 2,
-    ACTIONS(154), 4,
+  [521] = 3,
+    ACTIONS(152), 1,
+      anon_sym_QMARK,
+    ACTIONS(150), 4,
       anon_sym_LPAREN_QMARK,
       anon_sym_LPAREN,
       sym_control_escape,
       sym_identity_escape,
-    ACTIONS(152), 17,
+    ACTIONS(148), 17,
       ts_builtin_sym_end,
       anon_sym_PIPE,
       sym_any_character,
@@ -1716,17 +1849,91 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
       sym_pattern_character,
       anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_BSLASHk,
       sym_decimal_escape,
       aux_sym_character_class_escape_token1,
       aux_sym_character_class_escape_token2,
       sym_control_letter_escape,
-  [545] = 2,
+  [550] = 3,
+    ACTIONS(158), 1,
+      anon_sym_QMARK,
     ACTIONS(156), 4,
+      anon_sym_LPAREN_QMARK,
+      anon_sym_LPAREN,
+      sym_control_escape,
+      sym_identity_escape,
+    ACTIONS(154), 17,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_any_character,
+      anon_sym_CARET,
+      sym_end_assertion,
+      sym_boundary_assertion,
+      sym_non_boundary_assertion,
+      anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
+      sym_pattern_character,
+      anon_sym_LBRACK,
+      anon_sym_LPAREN_QMARK_COLON,
+      anon_sym_BSLASHk,
+      sym_decimal_escape,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_letter_escape,
+  [579] = 2,
+    ACTIONS(162), 4,
+      anon_sym_LPAREN_QMARK,
+      anon_sym_LPAREN,
+      sym_control_escape,
+      sym_identity_escape,
+    ACTIONS(160), 17,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_any_character,
+      anon_sym_CARET,
+      sym_end_assertion,
+      sym_boundary_assertion,
+      sym_non_boundary_assertion,
+      anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
+      sym_pattern_character,
+      anon_sym_LBRACK,
+      anon_sym_LPAREN_QMARK_COLON,
+      anon_sym_BSLASHk,
+      sym_decimal_escape,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_letter_escape,
+  [605] = 2,
+    ACTIONS(166), 4,
+      anon_sym_LPAREN_QMARK,
+      anon_sym_LPAREN,
+      sym_control_escape,
+      sym_identity_escape,
+    ACTIONS(164), 17,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_any_character,
+      anon_sym_CARET,
+      sym_end_assertion,
+      sym_boundary_assertion,
+      sym_non_boundary_assertion,
+      anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
+      sym_pattern_character,
+      anon_sym_LBRACK,
+      anon_sym_LPAREN_QMARK_COLON,
+      anon_sym_BSLASHk,
+      sym_decimal_escape,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_letter_escape,
+  [631] = 2,
+    ACTIONS(168), 4,
       anon_sym_LPAREN_QMARK,
       anon_sym_LPAREN,
       sym_control_escape,
@@ -1740,88 +1947,16 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
       sym_pattern_character,
       anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_BSLASHk,
       sym_decimal_escape,
       aux_sym_character_class_escape_token1,
       aux_sym_character_class_escape_token2,
       sym_control_letter_escape,
-  [571] = 2,
-    ACTIONS(160), 4,
-      anon_sym_LPAREN_QMARK,
-      anon_sym_LPAREN,
-      sym_control_escape,
-      sym_identity_escape,
-    ACTIONS(158), 17,
-      ts_builtin_sym_end,
-      anon_sym_PIPE,
-      sym_any_character,
-      anon_sym_CARET,
-      sym_end_assertion,
-      sym_boundary_assertion,
-      sym_non_boundary_assertion,
-      anon_sym_RPAREN,
-      sym_pattern_character,
-      anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
-      anon_sym_LPAREN_QMARK_COLON,
-      anon_sym_BSLASHk,
-      sym_decimal_escape,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_letter_escape,
-  [597] = 2,
-    ACTIONS(164), 4,
-      anon_sym_LPAREN_QMARK,
-      anon_sym_LPAREN,
-      sym_control_escape,
-      sym_identity_escape,
-    ACTIONS(162), 17,
-      ts_builtin_sym_end,
-      anon_sym_PIPE,
-      sym_any_character,
-      anon_sym_CARET,
-      sym_end_assertion,
-      sym_boundary_assertion,
-      sym_non_boundary_assertion,
-      anon_sym_RPAREN,
-      sym_pattern_character,
-      anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
-      anon_sym_LPAREN_QMARK_COLON,
-      anon_sym_BSLASHk,
-      sym_decimal_escape,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_letter_escape,
-  [623] = 2,
-    ACTIONS(168), 4,
-      anon_sym_LPAREN_QMARK,
-      anon_sym_LPAREN,
-      sym_control_escape,
-      sym_identity_escape,
-    ACTIONS(166), 17,
-      ts_builtin_sym_end,
-      anon_sym_PIPE,
-      sym_any_character,
-      anon_sym_CARET,
-      sym_end_assertion,
-      sym_boundary_assertion,
-      sym_non_boundary_assertion,
-      anon_sym_RPAREN,
-      sym_pattern_character,
-      anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
-      anon_sym_LPAREN_QMARK_COLON,
-      anon_sym_BSLASHk,
-      sym_decimal_escape,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_letter_escape,
-  [649] = 2,
+  [657] = 2,
     ACTIONS(172), 4,
       anon_sym_LPAREN_QMARK,
       anon_sym_LPAREN,
@@ -1836,125 +1971,173 @@ static const uint16_t ts_small_parse_table[] = {
       sym_boundary_assertion,
       sym_non_boundary_assertion,
       anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
       sym_pattern_character,
       anon_sym_LBRACK,
-      anon_sym_LPAREN_QMARK_LT,
       anon_sym_LPAREN_QMARK_COLON,
       anon_sym_BSLASHk,
       sym_decimal_escape,
       aux_sym_character_class_escape_token1,
       aux_sym_character_class_escape_token2,
       sym_control_letter_escape,
-  [675] = 8,
-    ACTIONS(174), 1,
+  [683] = 2,
+    ACTIONS(176), 4,
+      anon_sym_LPAREN_QMARK,
+      anon_sym_LPAREN,
+      sym_control_escape,
+      sym_identity_escape,
+    ACTIONS(174), 17,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_any_character,
       anon_sym_CARET,
-    ACTIONS(176), 1,
-      anon_sym_RBRACK,
-    ACTIONS(178), 1,
-      anon_sym_DASH,
-    ACTIONS(182), 1,
+      sym_end_assertion,
+      sym_boundary_assertion,
+      sym_non_boundary_assertion,
+      anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
+      sym_pattern_character,
+      anon_sym_LBRACK,
+      anon_sym_LPAREN_QMARK_COLON,
+      anon_sym_BSLASHk,
+      sym_decimal_escape,
       aux_sym_character_class_escape_token1,
-    ACTIONS(184), 1,
       aux_sym_character_class_escape_token2,
-    STATE(41), 1,
-      sym_character_class_escape,
-    STATE(34), 2,
-      sym_class_range,
-      aux_sym_character_class_repeat1,
-    ACTIONS(180), 5,
-      anon_sym_BSLASH_DASH,
-      sym_class_character,
-      sym_control_escape,
       sym_control_letter_escape,
+  [709] = 2,
+    ACTIONS(180), 4,
+      anon_sym_LPAREN_QMARK,
+      anon_sym_LPAREN,
+      sym_control_escape,
       sym_identity_escape,
-  [705] = 8,
+    ACTIONS(178), 17,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_any_character,
+      anon_sym_CARET,
+      sym_end_assertion,
+      sym_boundary_assertion,
+      sym_non_boundary_assertion,
+      anon_sym_RPAREN,
+      anon_sym_LPAREN_QMARK_LT,
+      sym_pattern_character,
+      anon_sym_LBRACK,
+      anon_sym_LPAREN_QMARK_COLON,
+      anon_sym_BSLASHk,
+      sym_decimal_escape,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_letter_escape,
+  [735] = 8,
+    ACTIONS(182), 1,
+      anon_sym_CARET,
+    ACTIONS(184), 1,
+      anon_sym_RBRACK,
     ACTIONS(186), 1,
-      anon_sym_RBRACK,
-    ACTIONS(188), 1,
       anon_sym_DASH,
+    ACTIONS(190), 1,
+      aux_sym_character_class_escape_token1,
+    ACTIONS(192), 1,
+      aux_sym_character_class_escape_token2,
+    STATE(44), 1,
+      sym_character_class_escape,
+    STATE(37), 2,
+      sym_class_range,
+      aux_sym_character_class_repeat1,
+    ACTIONS(188), 5,
+      anon_sym_BSLASH_DASH,
+      sym_class_character,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [765] = 8,
+    ACTIONS(186), 1,
+      anon_sym_DASH,
+    ACTIONS(190), 1,
+      aux_sym_character_class_escape_token1,
+    ACTIONS(192), 1,
+      aux_sym_character_class_escape_token2,
     ACTIONS(194), 1,
+      anon_sym_RBRACK,
+    ACTIONS(196), 1,
       sym_class_character,
-    ACTIONS(197), 1,
+    STATE(44), 1,
+      sym_character_class_escape,
+    STATE(39), 2,
+      sym_class_range,
+      aux_sym_character_class_repeat1,
+    ACTIONS(188), 4,
+      anon_sym_BSLASH_DASH,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [794] = 8,
+    ACTIONS(186), 1,
+      anon_sym_DASH,
+    ACTIONS(190), 1,
       aux_sym_character_class_escape_token1,
+    ACTIONS(192), 1,
+      aux_sym_character_class_escape_token2,
+    ACTIONS(194), 1,
+      anon_sym_RBRACK,
+    ACTIONS(196), 1,
+      sym_class_character,
+    STATE(44), 1,
+      sym_character_class_escape,
+    STATE(38), 2,
+      sym_class_range,
+      aux_sym_character_class_repeat1,
+    ACTIONS(188), 4,
+      anon_sym_BSLASH_DASH,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [823] = 8,
+    ACTIONS(198), 1,
+      anon_sym_RBRACK,
     ACTIONS(200), 1,
-      aux_sym_character_class_escape_token2,
-    STATE(41), 1,
-      sym_character_class_escape,
-    STATE(33), 2,
-      sym_class_range,
-      aux_sym_character_class_repeat1,
-    ACTIONS(191), 4,
-      anon_sym_BSLASH_DASH,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [734] = 8,
-    ACTIONS(178), 1,
       anon_sym_DASH,
-    ACTIONS(182), 1,
-      aux_sym_character_class_escape_token1,
-    ACTIONS(184), 1,
-      aux_sym_character_class_escape_token2,
-    ACTIONS(203), 1,
-      anon_sym_RBRACK,
-    ACTIONS(205), 1,
+    ACTIONS(206), 1,
       sym_class_character,
-    STATE(41), 1,
+    ACTIONS(209), 1,
+      aux_sym_character_class_escape_token1,
+    ACTIONS(212), 1,
+      aux_sym_character_class_escape_token2,
+    STATE(44), 1,
       sym_character_class_escape,
-    STATE(33), 2,
+    STATE(38), 2,
       sym_class_range,
       aux_sym_character_class_repeat1,
-    ACTIONS(180), 4,
+    ACTIONS(203), 4,
       anon_sym_BSLASH_DASH,
       sym_control_escape,
       sym_control_letter_escape,
       sym_identity_escape,
-  [763] = 8,
-    ACTIONS(178), 1,
+  [852] = 8,
+    ACTIONS(186), 1,
       anon_sym_DASH,
-    ACTIONS(182), 1,
+    ACTIONS(190), 1,
       aux_sym_character_class_escape_token1,
-    ACTIONS(184), 1,
+    ACTIONS(192), 1,
       aux_sym_character_class_escape_token2,
-    ACTIONS(203), 1,
-      anon_sym_RBRACK,
-    ACTIONS(205), 1,
+    ACTIONS(196), 1,
       sym_class_character,
-    STATE(41), 1,
+    ACTIONS(215), 1,
+      anon_sym_RBRACK,
+    STATE(44), 1,
       sym_character_class_escape,
-    STATE(36), 2,
+    STATE(38), 2,
       sym_class_range,
       aux_sym_character_class_repeat1,
-    ACTIONS(180), 4,
+    ACTIONS(188), 4,
       anon_sym_BSLASH_DASH,
       sym_control_escape,
       sym_control_letter_escape,
       sym_identity_escape,
-  [792] = 8,
-    ACTIONS(178), 1,
-      anon_sym_DASH,
-    ACTIONS(182), 1,
-      aux_sym_character_class_escape_token1,
-    ACTIONS(184), 1,
-      aux_sym_character_class_escape_token2,
-    ACTIONS(205), 1,
+  [881] = 2,
+    ACTIONS(219), 1,
       sym_class_character,
-    ACTIONS(207), 1,
-      anon_sym_RBRACK,
-    STATE(41), 1,
-      sym_character_class_escape,
-    STATE(33), 2,
-      sym_class_range,
-      aux_sym_character_class_repeat1,
-    ACTIONS(180), 4,
-      anon_sym_BSLASH_DASH,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [821] = 2,
-    ACTIONS(82), 1,
-      sym_class_character,
-    ACTIONS(84), 8,
+    ACTIONS(217), 8,
       anon_sym_RBRACK,
       anon_sym_DASH,
       anon_sym_BSLASH_DASH,
@@ -1963,7 +2146,113 @@ static const uint16_t ts_small_parse_table[] = {
       sym_control_escape,
       sym_control_letter_escape,
       sym_identity_escape,
-  [835] = 2,
+  [895] = 3,
+    ACTIONS(223), 1,
+      anon_sym_DASH,
+    ACTIONS(226), 1,
+      sym_class_character,
+    ACTIONS(221), 7,
+      anon_sym_RBRACK,
+      anon_sym_BSLASH_DASH,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [911] = 2,
+    ACTIONS(230), 1,
+      sym_class_character,
+    ACTIONS(228), 8,
+      anon_sym_RBRACK,
+      anon_sym_DASH,
+      anon_sym_BSLASH_DASH,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [925] = 2,
+    ACTIONS(234), 1,
+      sym_class_character,
+    ACTIONS(232), 8,
+      anon_sym_RBRACK,
+      anon_sym_DASH,
+      anon_sym_BSLASH_DASH,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [939] = 3,
+    ACTIONS(238), 1,
+      anon_sym_DASH,
+    ACTIONS(241), 1,
+      sym_class_character,
+    ACTIONS(236), 7,
+      anon_sym_RBRACK,
+      anon_sym_BSLASH_DASH,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [955] = 2,
+    ACTIONS(78), 1,
+      sym_class_character,
+    ACTIONS(80), 8,
+      anon_sym_RBRACK,
+      anon_sym_DASH,
+      anon_sym_BSLASH_DASH,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [969] = 2,
+    ACTIONS(245), 1,
+      sym_class_character,
+    ACTIONS(243), 8,
+      anon_sym_RBRACK,
+      anon_sym_DASH,
+      anon_sym_BSLASH_DASH,
+      aux_sym_character_class_escape_token1,
+      aux_sym_character_class_escape_token2,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [983] = 6,
+    ACTIONS(190), 1,
+      aux_sym_character_class_escape_token1,
+    ACTIONS(192), 1,
+      aux_sym_character_class_escape_token2,
+    ACTIONS(247), 1,
+      anon_sym_DASH,
+    ACTIONS(251), 1,
+      sym_class_character,
+    STATE(42), 1,
+      sym_character_class_escape,
+    ACTIONS(249), 4,
+      anon_sym_BSLASH_DASH,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [1005] = 6,
+    ACTIONS(190), 1,
+      aux_sym_character_class_escape_token1,
+    ACTIONS(192), 1,
+      aux_sym_character_class_escape_token2,
+    ACTIONS(253), 1,
+      anon_sym_DASH,
+    ACTIONS(257), 1,
+      sym_class_character,
+    STATE(43), 1,
+      sym_character_class_escape,
+    ACTIONS(255), 4,
+      anon_sym_BSLASH_DASH,
+      sym_control_escape,
+      sym_control_letter_escape,
+      sym_identity_escape,
+  [1027] = 2,
     ACTIONS(106), 1,
       sym_class_character,
     ACTIONS(108), 8,
@@ -1975,447 +2264,354 @@ static const uint16_t ts_small_parse_table[] = {
       sym_control_escape,
       sym_control_letter_escape,
       sym_identity_escape,
-  [849] = 2,
-    ACTIONS(211), 1,
-      sym_class_character,
-    ACTIONS(209), 8,
-      anon_sym_RBRACK,
-      anon_sym_DASH,
-      anon_sym_BSLASH_DASH,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [863] = 2,
-    ACTIONS(215), 1,
-      sym_class_character,
-    ACTIONS(213), 8,
-      anon_sym_RBRACK,
-      anon_sym_DASH,
-      anon_sym_BSLASH_DASH,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [877] = 3,
-    ACTIONS(219), 1,
-      anon_sym_DASH,
-    ACTIONS(222), 1,
-      sym_class_character,
-    ACTIONS(217), 7,
-      anon_sym_RBRACK,
-      anon_sym_BSLASH_DASH,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [893] = 3,
-    ACTIONS(226), 1,
-      anon_sym_DASH,
-    ACTIONS(229), 1,
-      sym_class_character,
-    ACTIONS(224), 7,
-      anon_sym_RBRACK,
-      anon_sym_BSLASH_DASH,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [909] = 2,
-    ACTIONS(233), 1,
-      sym_class_character,
-    ACTIONS(231), 8,
-      anon_sym_RBRACK,
-      anon_sym_DASH,
-      anon_sym_BSLASH_DASH,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [923] = 2,
-    ACTIONS(237), 1,
-      sym_class_character,
-    ACTIONS(235), 8,
-      anon_sym_RBRACK,
-      anon_sym_DASH,
-      anon_sym_BSLASH_DASH,
-      aux_sym_character_class_escape_token1,
-      aux_sym_character_class_escape_token2,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [937] = 6,
-    ACTIONS(182), 1,
-      aux_sym_character_class_escape_token1,
-    ACTIONS(184), 1,
-      aux_sym_character_class_escape_token2,
-    ACTIONS(239), 1,
-      anon_sym_DASH,
-    ACTIONS(243), 1,
-      sym_class_character,
-    STATE(43), 1,
-      sym_character_class_escape,
-    ACTIONS(241), 4,
-      anon_sym_BSLASH_DASH,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [959] = 6,
-    ACTIONS(182), 1,
-      aux_sym_character_class_escape_token1,
-    ACTIONS(184), 1,
-      aux_sym_character_class_escape_token2,
-    ACTIONS(245), 1,
-      anon_sym_DASH,
-    ACTIONS(249), 1,
-      sym_class_character,
-    STATE(39), 1,
-      sym_character_class_escape,
-    ACTIONS(247), 4,
-      anon_sym_BSLASH_DASH,
-      sym_control_escape,
-      sym_control_letter_escape,
-      sym_identity_escape,
-  [981] = 3,
+  [1041] = 3,
+    ACTIONS(3), 1,
+      anon_sym_PIPE,
+    STATE(51), 1,
+      aux_sym_alternation_repeat1,
+    ACTIONS(259), 2,
+      ts_builtin_sym_end,
+      anon_sym_RPAREN,
+  [1052] = 3,
+    ACTIONS(263), 1,
+      anon_sym_PIPE,
+    STATE(51), 1,
+      aux_sym_alternation_repeat1,
+    ACTIONS(261), 2,
+      ts_builtin_sym_end,
+      anon_sym_RPAREN,
+  [1063] = 3,
+    ACTIONS(3), 1,
+      anon_sym_PIPE,
+    STATE(51), 1,
+      aux_sym_alternation_repeat1,
+    ACTIONS(266), 2,
+      ts_builtin_sym_end,
+      anon_sym_RPAREN,
+  [1074] = 3,
     ACTIONS(3), 1,
       anon_sym_PIPE,
     STATE(50), 1,
       aux_sym_alternation_repeat1,
-    ACTIONS(251), 2,
+    ACTIONS(268), 2,
       ts_builtin_sym_end,
       anon_sym_RPAREN,
-  [992] = 3,
-    ACTIONS(3), 1,
-      anon_sym_PIPE,
-    STATE(50), 1,
-      aux_sym_alternation_repeat1,
-    ACTIONS(253), 2,
-      ts_builtin_sym_end,
-      anon_sym_RPAREN,
-  [1003] = 3,
-    ACTIONS(3), 1,
-      anon_sym_PIPE,
-    STATE(48), 1,
-      aux_sym_alternation_repeat1,
-    ACTIONS(255), 2,
-      ts_builtin_sym_end,
-      anon_sym_RPAREN,
-  [1014] = 3,
-    ACTIONS(259), 1,
-      anon_sym_PIPE,
-    STATE(50), 1,
-      aux_sym_alternation_repeat1,
-    ACTIONS(257), 2,
-      ts_builtin_sym_end,
-      anon_sym_RPAREN,
-  [1025] = 1,
-    ACTIONS(262), 4,
+  [1085] = 2,
+    ACTIONS(272), 1,
+      sym_group_name,
+    ACTIONS(270), 2,
       anon_sym_EQ,
       anon_sym_BANG,
-      anon_sym_LT_EQ,
-      anon_sym_LT_BANG,
-  [1032] = 1,
-    ACTIONS(257), 3,
+  [1093] = 1,
+    ACTIONS(261), 3,
       ts_builtin_sym_end,
       anon_sym_PIPE,
       anon_sym_RPAREN,
-  [1038] = 2,
-    ACTIONS(264), 1,
+  [1099] = 2,
+    ACTIONS(274), 1,
       anon_sym_EQ,
-    ACTIONS(266), 1,
+    ACTIONS(276), 1,
       anon_sym_RBRACE,
-  [1045] = 2,
-    ACTIONS(268), 1,
-      sym_unicode_property,
-    STATE(72), 1,
-      sym_unicode_property_value_expression,
-  [1052] = 2,
-    ACTIONS(268), 1,
-      sym_unicode_property,
-    STATE(62), 1,
-      sym_unicode_property_value_expression,
-  [1059] = 1,
-    ACTIONS(255), 2,
+  [1106] = 1,
+    ACTIONS(278), 2,
+      anon_sym_EQ,
+      anon_sym_BANG,
+  [1111] = 1,
+    ACTIONS(268), 2,
       ts_builtin_sym_end,
       anon_sym_RPAREN,
-  [1064] = 2,
-    ACTIONS(270), 1,
-      anon_sym_COMMA,
-    ACTIONS(272), 1,
-      anon_sym_RBRACE,
-  [1071] = 1,
-    ACTIONS(274), 1,
-      sym_unicode_property,
-  [1075] = 1,
-    ACTIONS(276), 1,
-      sym_group_name,
-  [1079] = 1,
-    ACTIONS(278), 1,
-      anon_sym_RPAREN,
-  [1083] = 1,
+  [1116] = 2,
     ACTIONS(280), 1,
-      anon_sym_RPAREN,
-  [1087] = 1,
+      sym_unicode_property,
+    STATE(74), 1,
+      sym_unicode_property_value_expression,
+  [1123] = 2,
+    ACTIONS(280), 1,
+      sym_unicode_property,
+    STATE(76), 1,
+      sym_unicode_property_value_expression,
+  [1130] = 2,
     ACTIONS(282), 1,
-      anon_sym_RBRACE,
-  [1091] = 1,
+      anon_sym_COMMA,
     ACTIONS(284), 1,
-      sym_group_name,
-  [1095] = 1,
+      anon_sym_RBRACE,
+  [1137] = 1,
     ACTIONS(286), 1,
-      anon_sym_RBRACE,
-  [1099] = 1,
-    ACTIONS(288), 1,
-      sym_decimal_digits,
-  [1103] = 1,
-    ACTIONS(290), 1,
-      sym_decimal_digits,
-  [1107] = 1,
-    ACTIONS(292), 1,
-      anon_sym_RBRACE,
-  [1111] = 1,
-    ACTIONS(294), 1,
       anon_sym_LBRACE,
-  [1115] = 1,
+  [1141] = 1,
+    ACTIONS(288), 1,
+      anon_sym_RPAREN,
+  [1145] = 1,
+    ACTIONS(290), 1,
+      anon_sym_RPAREN,
+  [1149] = 1,
+    ACTIONS(292), 1,
+      sym_group_name,
+  [1153] = 1,
+    ACTIONS(294), 1,
+      sym_unicode_property,
+  [1157] = 1,
     ACTIONS(296), 1,
       anon_sym_RPAREN,
-  [1119] = 1,
+  [1161] = 1,
     ACTIONS(298), 1,
-      anon_sym_GT,
-  [1123] = 1,
+      anon_sym_RBRACE,
+  [1165] = 1,
     ACTIONS(300), 1,
       anon_sym_RPAREN,
-  [1127] = 1,
+  [1169] = 1,
     ACTIONS(302), 1,
-      anon_sym_RBRACE,
-  [1131] = 1,
-    ACTIONS(304), 1,
       ts_builtin_sym_end,
-  [1135] = 1,
+  [1173] = 1,
+    ACTIONS(304), 1,
+      anon_sym_RBRACE,
+  [1177] = 1,
     ACTIONS(306), 1,
+      sym_decimal_digits,
+  [1181] = 1,
+    ACTIONS(308), 1,
+      anon_sym_GT,
+  [1185] = 1,
+    ACTIONS(310), 1,
+      anon_sym_RBRACE,
+  [1189] = 1,
+    ACTIONS(312), 1,
+      sym_decimal_digits,
+  [1193] = 1,
+    ACTIONS(314), 1,
+      anon_sym_RBRACE,
+  [1197] = 1,
+    ACTIONS(316), 1,
+      anon_sym_RPAREN,
+  [1201] = 1,
+    ACTIONS(318), 1,
       anon_sym_LBRACE,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(9)] = 0,
-  [SMALL_STATE(10)] = 44,
-  [SMALL_STATE(11)] = 74,
-  [SMALL_STATE(12)] = 104,
-  [SMALL_STATE(13)] = 134,
-  [SMALL_STATE(14)] = 164,
-  [SMALL_STATE(15)] = 194,
-  [SMALL_STATE(16)] = 224,
-  [SMALL_STATE(17)] = 254,
-  [SMALL_STATE(18)] = 284,
-  [SMALL_STATE(19)] = 314,
-  [SMALL_STATE(20)] = 344,
-  [SMALL_STATE(21)] = 374,
-  [SMALL_STATE(22)] = 403,
-  [SMALL_STATE(23)] = 432,
-  [SMALL_STATE(24)] = 461,
-  [SMALL_STATE(25)] = 490,
-  [SMALL_STATE(26)] = 519,
-  [SMALL_STATE(27)] = 545,
-  [SMALL_STATE(28)] = 571,
-  [SMALL_STATE(29)] = 597,
-  [SMALL_STATE(30)] = 623,
-  [SMALL_STATE(31)] = 649,
-  [SMALL_STATE(32)] = 675,
-  [SMALL_STATE(33)] = 705,
-  [SMALL_STATE(34)] = 734,
-  [SMALL_STATE(35)] = 763,
-  [SMALL_STATE(36)] = 792,
-  [SMALL_STATE(37)] = 821,
-  [SMALL_STATE(38)] = 835,
-  [SMALL_STATE(39)] = 849,
-  [SMALL_STATE(40)] = 863,
-  [SMALL_STATE(41)] = 877,
-  [SMALL_STATE(42)] = 893,
-  [SMALL_STATE(43)] = 909,
-  [SMALL_STATE(44)] = 923,
-  [SMALL_STATE(45)] = 937,
-  [SMALL_STATE(46)] = 959,
-  [SMALL_STATE(47)] = 981,
-  [SMALL_STATE(48)] = 992,
-  [SMALL_STATE(49)] = 1003,
-  [SMALL_STATE(50)] = 1014,
-  [SMALL_STATE(51)] = 1025,
-  [SMALL_STATE(52)] = 1032,
-  [SMALL_STATE(53)] = 1038,
-  [SMALL_STATE(54)] = 1045,
-  [SMALL_STATE(55)] = 1052,
-  [SMALL_STATE(56)] = 1059,
-  [SMALL_STATE(57)] = 1064,
-  [SMALL_STATE(58)] = 1071,
-  [SMALL_STATE(59)] = 1075,
-  [SMALL_STATE(60)] = 1079,
-  [SMALL_STATE(61)] = 1083,
-  [SMALL_STATE(62)] = 1087,
-  [SMALL_STATE(63)] = 1091,
-  [SMALL_STATE(64)] = 1095,
-  [SMALL_STATE(65)] = 1099,
-  [SMALL_STATE(66)] = 1103,
-  [SMALL_STATE(67)] = 1107,
-  [SMALL_STATE(68)] = 1111,
-  [SMALL_STATE(69)] = 1115,
-  [SMALL_STATE(70)] = 1119,
-  [SMALL_STATE(71)] = 1123,
-  [SMALL_STATE(72)] = 1127,
-  [SMALL_STATE(73)] = 1131,
-  [SMALL_STATE(74)] = 1135,
+  [SMALL_STATE(10)] = 0,
+  [SMALL_STATE(11)] = 44,
+  [SMALL_STATE(12)] = 74,
+  [SMALL_STATE(13)] = 104,
+  [SMALL_STATE(14)] = 134,
+  [SMALL_STATE(15)] = 164,
+  [SMALL_STATE(16)] = 194,
+  [SMALL_STATE(17)] = 224,
+  [SMALL_STATE(18)] = 254,
+  [SMALL_STATE(19)] = 284,
+  [SMALL_STATE(20)] = 314,
+  [SMALL_STATE(21)] = 344,
+  [SMALL_STATE(22)] = 374,
+  [SMALL_STATE(23)] = 404,
+  [SMALL_STATE(24)] = 434,
+  [SMALL_STATE(25)] = 463,
+  [SMALL_STATE(26)] = 492,
+  [SMALL_STATE(27)] = 521,
+  [SMALL_STATE(28)] = 550,
+  [SMALL_STATE(29)] = 579,
+  [SMALL_STATE(30)] = 605,
+  [SMALL_STATE(31)] = 631,
+  [SMALL_STATE(32)] = 657,
+  [SMALL_STATE(33)] = 683,
+  [SMALL_STATE(34)] = 709,
+  [SMALL_STATE(35)] = 735,
+  [SMALL_STATE(36)] = 765,
+  [SMALL_STATE(37)] = 794,
+  [SMALL_STATE(38)] = 823,
+  [SMALL_STATE(39)] = 852,
+  [SMALL_STATE(40)] = 881,
+  [SMALL_STATE(41)] = 895,
+  [SMALL_STATE(42)] = 911,
+  [SMALL_STATE(43)] = 925,
+  [SMALL_STATE(44)] = 939,
+  [SMALL_STATE(45)] = 955,
+  [SMALL_STATE(46)] = 969,
+  [SMALL_STATE(47)] = 983,
+  [SMALL_STATE(48)] = 1005,
+  [SMALL_STATE(49)] = 1027,
+  [SMALL_STATE(50)] = 1041,
+  [SMALL_STATE(51)] = 1052,
+  [SMALL_STATE(52)] = 1063,
+  [SMALL_STATE(53)] = 1074,
+  [SMALL_STATE(54)] = 1085,
+  [SMALL_STATE(55)] = 1093,
+  [SMALL_STATE(56)] = 1099,
+  [SMALL_STATE(57)] = 1106,
+  [SMALL_STATE(58)] = 1111,
+  [SMALL_STATE(59)] = 1116,
+  [SMALL_STATE(60)] = 1123,
+  [SMALL_STATE(61)] = 1130,
+  [SMALL_STATE(62)] = 1137,
+  [SMALL_STATE(63)] = 1141,
+  [SMALL_STATE(64)] = 1145,
+  [SMALL_STATE(65)] = 1149,
+  [SMALL_STATE(66)] = 1153,
+  [SMALL_STATE(67)] = 1157,
+  [SMALL_STATE(68)] = 1161,
+  [SMALL_STATE(69)] = 1165,
+  [SMALL_STATE(70)] = 1169,
+  [SMALL_STATE(71)] = 1173,
+  [SMALL_STATE(72)] = 1177,
+  [SMALL_STATE(73)] = 1181,
+  [SMALL_STATE(74)] = 1185,
+  [SMALL_STATE(75)] = 1189,
+  [SMALL_STATE(76)] = 1193,
+  [SMALL_STATE(77)] = 1197,
+  [SMALL_STATE(78)] = 1201,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
   [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_alternation_repeat1, 1),
   [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2),
-  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(9),
-  [34] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(12),
-  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(51),
-  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(32),
-  [43] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(4),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(63),
-  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(5),
-  [52] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(59),
-  [55] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(11),
-  [58] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(68),
-  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(9),
+  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(10),
+  [34] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(13),
+  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(57),
+  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(54),
+  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(35),
+  [46] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(5),
+  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(6),
+  [52] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(65),
+  [55] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(18),
+  [58] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(62),
+  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 2), SHIFT_REPEAT(10),
   [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_term, 1),
   [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_term_repeat1, 1),
   [68] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 1),
-  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lookahead_assertion, 4),
-  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_lookahead_assertion, 4),
-  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class_escape, 1),
-  [84] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class_escape, 1),
+  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class_escape, 4),
+  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class_escape, 4),
+  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__lookahead_assertion, 4),
+  [84] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__lookahead_assertion, 4),
   [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_assertion, 1),
   [88] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_assertion, 1),
   [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_non_capturing_group, 3),
   [92] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_non_capturing_group, 3),
-  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class, 4),
-  [96] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class, 4),
-  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_anonymous_capturing_group, 3),
-  [100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_anonymous_capturing_group, 3),
+  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_anonymous_capturing_group, 3),
+  [96] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_anonymous_capturing_group, 3),
+  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lookaround_assertion, 1),
+  [100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_lookaround_assertion, 1),
   [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class, 3),
   [104] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class, 3),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class_escape, 4),
-  [108] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class_escape, 4),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_named_capturing_group, 5),
-  [112] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_named_capturing_group, 5),
-  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_backreference_escape, 2),
-  [116] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_backreference_escape, 2),
-  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class, 2),
-  [120] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class, 2),
-  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_count_quantifier, 3),
-  [124] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_count_quantifier, 3),
-  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional, 1),
-  [130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional, 1),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [134] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_one_or_more, 1),
-  [136] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_one_or_more, 1),
-  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [140] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_zero_or_more, 1),
-  [142] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_zero_or_more, 1),
-  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [146] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_count_quantifier, 5),
-  [148] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_count_quantifier, 5),
-  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_count_quantifier, 6, .production_id = 7),
-  [154] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_count_quantifier, 6, .production_id = 7),
-  [156] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 2),
-  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_one_or_more, 2, .production_id = 2),
-  [160] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_one_or_more, 2, .production_id = 2),
-  [162] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional, 2, .production_id = 2),
-  [164] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional, 2, .production_id = 2),
-  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_zero_or_more, 2, .production_id = 2),
-  [168] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_zero_or_more, 2, .production_id = 2),
+  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class_escape, 1),
+  [108] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class_escape, 1),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__lookbehind_assertion, 4),
+  [112] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__lookbehind_assertion, 4),
+  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class, 4),
+  [116] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class, 4),
+  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_backreference_escape, 2),
+  [120] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_backreference_escape, 2),
+  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_named_capturing_group, 5),
+  [124] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_named_capturing_group, 5),
+  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_character_class, 2),
+  [128] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_character_class, 2),
+  [130] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_count_quantifier, 3),
+  [132] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_count_quantifier, 3),
+  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_one_or_more, 1),
+  [138] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_one_or_more, 1),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_count_quantifier, 5),
+  [144] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_count_quantifier, 5),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional, 1),
+  [150] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional, 1),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_zero_or_more, 1),
+  [156] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_zero_or_more, 1),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [160] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_zero_or_more, 2, .production_id = 2),
+  [162] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_zero_or_more, 2, .production_id = 2),
+  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_count_quantifier, 6, .production_id = 7),
+  [166] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_count_quantifier, 6, .production_id = 7),
+  [168] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_term_repeat1, 2),
   [170] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_count_quantifier, 4, .production_id = 5),
   [172] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_count_quantifier, 4, .production_id = 5),
-  [174] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [176] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [178] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
-  [180] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [182] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [184] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [186] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2),
-  [188] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(42),
-  [191] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(41),
-  [194] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(41),
-  [197] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(37),
-  [200] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(74),
-  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [207] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
-  [209] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_range, 3),
-  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_range, 3),
-  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_range, 3, .production_id = 4),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_range, 3, .production_id = 4),
-  [217] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 1),
-  [219] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 1), SHIFT(46),
-  [222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_character_class_repeat1, 1),
-  [224] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 1, .production_id = 1),
-  [226] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 1, .production_id = 1), SHIFT(45),
-  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_character_class_repeat1, 1, .production_id = 1),
-  [231] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_range, 3, .production_id = 1),
-  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_range, 3, .production_id = 1),
-  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_range, 3, .production_id = 3),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_range, 3, .production_id = 3),
-  [239] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [241] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [245] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [247] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alternation, 1),
-  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alternation, 2),
-  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pattern, 1),
-  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_alternation_repeat1, 2),
-  [259] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_alternation_repeat1, 2), SHIFT_REPEAT(6),
-  [262] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unicode_property_value_expression, 1),
-  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [284] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [288] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [292] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unicode_property_value_expression, 3, .production_id = 6),
-  [294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [304] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [174] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional, 2, .production_id = 2),
+  [176] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional, 2, .production_id = 2),
+  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_one_or_more, 2, .production_id = 2),
+  [180] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_one_or_more, 2, .production_id = 2),
+  [182] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [184] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [186] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [188] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
+  [190] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [192] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [194] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [198] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2),
+  [200] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(41),
+  [203] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(44),
+  [206] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(44),
+  [209] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(49),
+  [212] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 2), SHIFT_REPEAT(78),
+  [215] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [217] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_range, 3, .production_id = 4),
+  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_range, 3, .production_id = 4),
+  [221] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 1, .production_id = 1),
+  [223] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 1, .production_id = 1), SHIFT(47),
+  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_character_class_repeat1, 1, .production_id = 1),
+  [228] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_range, 3, .production_id = 1),
+  [230] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_range, 3, .production_id = 1),
+  [232] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_range, 3),
+  [234] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_range, 3),
+  [236] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 1),
+  [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_character_class_repeat1, 1), SHIFT(48),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_character_class_repeat1, 1),
+  [243] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_range, 3, .production_id = 3),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_range, 3, .production_id = 3),
+  [247] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [249] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [253] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [255] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
+  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alternation, 2),
+  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_alternation_repeat1, 2),
+  [263] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_alternation_repeat1, 2), SHIFT_REPEAT(7),
+  [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alternation, 1),
+  [268] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pattern, 1),
+  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [276] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unicode_property_value_expression, 1),
+  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [284] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [288] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [302] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [304] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unicode_property_value_expression, 3, .production_id = 6),
+  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [318] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
 };
 
 #ifdef __cplusplus
@@ -2448,6 +2644,7 @@ extern const TSLanguage *tree_sitter_regex(void) {
     .alias_sequences = &ts_alias_sequences[0][0],
     .lex_modes = ts_lex_modes,
     .lex_fn = ts_lex,
+    .primary_state_ids = ts_primary_state_ids,
   };
   return &language;
 }

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
closes #13 
based on #14

Here we split lookbehind and lookahead assertions into unnamed rules and use `lookaround_assertion` to group them. We need to split out lookbehinds because `named_capture_group` uses `(?<` as a token which seems to confuse the error recovery.

https://github.com/tree-sitter/tree-sitter-regex/blob/e1cfca3c79896ff79842f057ea13e529b66af636/grammar.js#L105

Also a maintenence commit here for bumping to 0.20.6 of the CLI.