### PR TITLE
rework release logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,80 +3,101 @@ name: Release
 on:
   workflow_run:
     workflows: ["CI"]
+    branches:
+      - master
     types:
       - completed
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/master' }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
-        id: release
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
-          release-type: node
-          package-name: tree-sitter-regex
+          fetch-depth: 0
 
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update Rust version
+      - name: Get previous commit SHA
+        id: get_previous_commit
         run: |
-          git fetch origin release-please--branches--master--components--tree-sitter-regex
-          git checkout release-please--branches--master--components--tree-sitter-regex
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          if [[ -z "$LATEST_TAG" ]]; then
+            echo "No tag found. Failing..."
+            exit 1
+          fi
+          echo "latest_tag=${LATEST_TAG#v}" >> "$GITHUB_ENV" # Remove 'v' prefix from the tag
 
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
+      - name: Check if version changed and is greater than the previous
+        id: version_check
+        run: |
+          # Compare the current version with the version from the previous commit
+          PREVIOUS_NPM_VERSION=${{ env.latest_tag }}
+          CURRENT_NPM_VERSION=$(jq -r '.version' package.json)
+          CURRENT_CARGO_VERSION=$(awk -F '"' '/^version/ {print $2}' Cargo.toml)
+          if [[ "$CURRENT_NPM_VERSION" != "$CURRENT_CARGO_VERSION" ]]; then # Cargo.toml and package.json versions must match
+            echo "Mismatch: NPM version ($CURRENT_NPM_VERSION) and Cargo.toml version ($CURRENT_CARGO_VERSION)"
+            echo "version_changed=false" >> "$GITHUB_ENV"
+          else
+            if [[ "$PREVIOUS_NPM_VERSION" ==  "$CURRENT_NPM_VERSION" ]]; then
+              echo "version_changed=" >> "$GITHUB_ENV"
+            else
+              IFS='.' read -ra PREVIOUS_VERSION_PARTS <<< "$PREVIOUS_NPM_VERSION"
+              IFS='.' read -ra CURRENT_VERSION_PARTS <<< "$CURRENT_NPM_VERSION"
+              VERSION_CHANGED=false
+              for i in "${!PREVIOUS_VERSION_PARTS[@]}"; do
+                if [[ ${CURRENT_VERSION_PARTS[i]} -gt ${PREVIOUS_VERSION_PARTS[i]} ]]; then
+                  VERSION_CHANGED=true
+                  break
+                elif [[ ${CURRENT_VERSION_PARTS[i]} -lt ${PREVIOUS_VERSION_PARTS[i]} ]]; then
+                  break
+                fi
+              done
 
-          repo_name="${{ github.repository }}"
-          repo_name="${repo_name##*/}"
-          version=$(grep -o '"version": *"[^"]*"' package.json | sed 's/"version": "\(.*\)"/\1/')
+              echo "version_changed=$VERSION_CHANGED" >> "$GITHUB_ENV"
+              echo "current_version=${CURRENT_NPM_VERSION}" >> "$GITHUB_ENV"
+            fi
+          fi
 
-          sed -i "s/version = \"[^\"]*\"/version = \"$version\"/g" Cargo.toml
-          sed -i "s/$repo_name = \"[^\"]*\"/$repo_name = \"$version\"/g" bindings/rust/README.md
+      - name: Display result
+        run: |
+          echo "Version bump detected: ${{ env.version_changed }}"
 
-          git add Cargo.toml bindings/rust/README.md
-          git commit --amend --no-edit
-          git push -f
+      - name: Fail if version is lower
+        if: env.version_changed == 'false'
+        run: exit 1
 
       - name: Setup Node
-        if: ${{ steps.release.outputs.release_created }}
+        if: env.version_changed == 'true'
         uses: actions/setup-node@v3
         with:
           node-version: 18
           registry-url: "https://registry.npmjs.org"
       - name: Publish to NPM
-        if: ${{ steps.release.outputs.release_created }}
+        if: env.version_changed == 'true'
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npm publish
 
       - name: Setup Rust
-        if: ${{ steps.release.outputs.release_created }}
+        if: env.version_changed == 'true'
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
       - name: Publish to Crates.io
-        if: ${{ steps.release.outputs.release_created }}
+        if: env.version_changed == 'true'
         uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Tag stable versions
-        if: ${{ steps.release.outputs.release_created }}
+      - name: Tag versions
+        if: env.version_changed == 'true'
         run: |
           git checkout master
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/google-github-actions/release-please-action.git"
-          git tag -d stable || true
-          git push origin :stable || true
-          git tag -a stable -m "Last Stable Release"
-          git push origin stable
+          git tag -d "v${{ env.current_version }}" || true
+          git push origin --delete "v${{ env.current_version }}" || true
+          git tag -a "v${{ env.current_version }}" -m "Version ${{ env.current_version }}"
+          git push origin "v${{ env.current_version }}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-regex",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "regex grammar for tree-sitter",
   "main": "bindings/node",
   "keywords": [


### PR DESCRIPTION
So, based on @maxbrunsfeld's notes from before, I can agree release-please could be a bit annoying w/ enforcing commit message semantics, despite the benefits that would bring

As a result, I've reworked the CI

Steps are as follows:
- Only run on master *if* CI passes successfully
- Find the latest tag and extract the version as the previous manifest versions
- Compare with the versions currently in package.json and Cargo.toml in master
- If it is less, fail, if it is equal, do nothing as version_changed will be blank and no subsequent publish/release related steps will be run
- If it is greater, first run publish actions, then tag a release, so that if the publish action fails we don't create a release with unassociated packages

I had to bump the version in package.json to be the same as Cargo.toml, as it won't work otherwise. If this is merged, the actions should run and v0.20.0 should be published and tagged

One more feature to add could be to block pull requests where version is changed by a non-maintainer in package.json or Cargo.toml
